### PR TITLE
feat: add demo data loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
       <!-- Buttons -->
       <button class="btn" onclick="addBet()">Add Bet</button>
       <button class="btn btn-danger" onclick="clearAllBets()">Clear All</button>
+      <button class="btn" onclick="loadDemoData()">Load Demo Bets</button>
     </div>
 
     <!-- SORT CONTROLS -->

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,56 @@ function saveBets() {
   localStorage.setItem('bettingData', JSON.stringify(bets));
 }
 
+function loadDemoData() {
+  bets = [
+    {
+      id: Date.now(),
+      date: '2023-09-01',
+      sport: 'Football',
+      event: 'Team A vs Team B',
+      betType: 'Moneyline',
+      odds: '+150',
+      stake: 50,
+      outcome: 'Win',
+      payout: calculatePayout('+150', 50),
+      profitLoss: calculatePayout('+150', 50) - 50,
+      description: 'Team A ML',
+      note: 'Demo'
+    },
+    {
+      id: Date.now() + 1,
+      date: '2023-09-02',
+      sport: 'Basketball',
+      event: 'Team C vs Team D',
+      betType: 'Point Spread',
+      odds: '-110',
+      stake: 40,
+      outcome: 'Loss',
+      payout: 0,
+      profitLoss: -40,
+      description: 'Team C -3.5',
+      note: ''
+    },
+    {
+      id: Date.now() + 2,
+      date: '2023-09-03',
+      sport: 'Baseball',
+      event: 'Team E vs Team F',
+      betType: 'Over/Under',
+      odds: '-105',
+      stake: 20,
+      outcome: 'Pending',
+      payout: 0,
+      profitLoss: 0,
+      description: 'Over 8.5',
+      note: ''
+    }
+  ];
+  saveBets();
+  renderBets();
+  updateStats();
+}
+
 function calculatePayout(odds, stake) {
   const numOdds = parseFloat(odds);
   if (isNaN(numOdds) || isNaN(stake)) return 0;
@@ -255,5 +305,9 @@ function exportToCSV() {
   window.URL.revokeObjectURL(url);
 }
 
-renderBets();
-updateStats();
+if (bets.length === 0 && new URLSearchParams(window.location.search).get('demo')) {
+  loadDemoData();
+} else {
+  renderBets();
+  updateStats();
+}

--- a/profile.html
+++ b/profile.html
@@ -75,6 +75,7 @@
             Win Streak: <span class="highlight" id="profile-win-streak">0</span>
           </div>
           <a href="index.html">← Back to Tracker</a>
+          <button class="btn" onclick="loadDemoData()">Load Demo Bets</button>
         </div>
       </div>
     </div>
@@ -279,6 +280,55 @@
       const row = button.closest('tr');
       const index = Array.from(row.parentNode.children).indexOf(row);
       bets.splice(index, 1);
+      localStorage.setItem('bettingData', JSON.stringify(bets));
+      location.reload();
+    }
+
+    function loadDemoData() {
+      bets = [
+        {
+          id: Date.now(),
+          date: '2023-09-01',
+          sport: 'Football',
+          event: 'Team A vs Team B',
+          betType: 'Moneyline',
+          odds: '+150',
+          stake: 50,
+          outcome: 'Win',
+          payout: 125,
+          profitLoss: 75,
+          description: 'Team A ML',
+          note: 'Demo'
+        },
+        {
+          id: Date.now() + 1,
+          date: '2023-09-02',
+          sport: 'Basketball',
+          event: 'Team C vs Team D',
+          betType: 'Point Spread',
+          odds: '-110',
+          stake: 40,
+          outcome: 'Loss',
+          payout: 0,
+          profitLoss: -40,
+          description: 'Team C -3.5',
+          note: ''
+        },
+        {
+          id: Date.now() + 2,
+          date: '2023-09-03',
+          sport: 'Baseball',
+          event: 'Team E vs Team F',
+          betType: 'Over/Under',
+          odds: '-105',
+          stake: 20,
+          outcome: 'Pending',
+          payout: 0,
+          profitLoss: 0,
+          description: 'Over 8.5',
+          note: ''
+        }
+      ];
       localStorage.setItem('bettingData', JSON.stringify(bets));
       location.reload();
     }


### PR DESCRIPTION
## Summary
- add helper to populate demo bets with win, loss, and pending examples
- expose a **Load Demo Bets** button on tracker and profile pages
- auto-populate demo data when visiting with `?demo=1`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_688fb96dfc3083239a6a1840dad0f332