### PR TITLE
Refactor bet removal to use bet IDs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -133,10 +133,8 @@ function addBet() {
   clearForm();
 }
 
-function removeBet(button) {
-  const row = button.closest('tr');
-  const index = Array.from(row.parentNode.children).indexOf(row);
-  bets.splice(index, 1);
+function removeBet(betId) {
+  bets = bets.filter(bet => bet.id !== betId);
   saveBets();
   renderBets();
   updateStats();
@@ -217,9 +215,9 @@ function renderBets() {
             <option value="Win">Win</option>
             <option value="Loss">Loss</option>
           </select>
-          <button class="btn btn-danger" onclick="removeBet(this)">Remove</button>
+          <button class="btn btn-danger" onclick="removeBet(${bet.id})">Remove</button>
         `
-        : `<button class="btn btn-danger" onclick="removeBet(this)">Remove</button>`
+        : `<button class="btn btn-danger" onclick="removeBet(${bet.id})">Remove</button>`
     }
   </td>
 `;

--- a/profile.html
+++ b/profile.html
@@ -237,20 +237,20 @@
             ${
               bet.outcome === 'Pending'
                 ? `
-                  <select onchange="settleBet(this, ${bet.id})">
-                    <option value="">Settle</option>
-                    <option value="Win">Win</option>
-                    <option value="Loss">Loss</option>
-                  </select>
-                  <button class="btn btn-danger" onclick="removeBet(this)">Remove</button>
-                `
-                : `<button class="btn btn-danger" onclick="removeBet(this)">Remove</button>`
-            }
-          </td>
-        `;
-        tbody.appendChild(row);
-      });
-    }
+                    <select onchange="settleBet(this, ${bet.id})">
+                      <option value="">Settle</option>
+                      <option value="Win">Win</option>
+                      <option value="Loss">Loss</option>
+                    </select>
+                    <button class="btn btn-danger" onclick="removeBet(${bet.id})">Remove</button>
+                  `
+                  : `<button class="btn btn-danger" onclick="removeBet(${bet.id})">Remove</button>`
+              }
+            </td>
+          `;
+          tbody.appendChild(row);
+        });
+      }
 
     function settleBet(selectEl, betId) {
       const newOutcome = selectEl.value;
@@ -276,13 +276,11 @@
       location.reload();
     }
 
-    function removeBet(button) {
-      const row = button.closest('tr');
-      const index = Array.from(row.parentNode.children).indexOf(row);
-      bets.splice(index, 1);
-      localStorage.setItem('bettingData', JSON.stringify(bets));
-      location.reload();
-    }
+      function removeBet(betId) {
+        bets = bets.filter(bet => bet.id !== betId);
+        localStorage.setItem('bettingData', JSON.stringify(bets));
+        location.reload();
+      }
 
     function loadDemoData() {
       bets = [


### PR DESCRIPTION
## Summary
- remove bets by identifier rather than table index in app.js and profile.html
- update rendered table rows to call `removeBet(bet.id)`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fc283896483239a046ef9c5fb65f0