### PR TITLE
Add truncated note preview for bets

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -134,6 +134,13 @@ td {
   border-bottom: 1px solid #ecf0f1;
 }
 
+.note-cell .note-content {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 tr:hover {
   background-color: #f8f9fa;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -205,7 +205,7 @@ function renderBets() {
   <td class="${profitClass}">${
     bet.outcome === 'Pending' ? '—' : profitSymbol + '$' + bet.profitLoss.toFixed(2)
   }</td>
-  <td>${bet.note || ''}</td>
+  <td class="note-cell"><div class="note-content" title="${bet.note || ''}">${bet.note || ''}</div></td>
   <td>
     ${
       bet.outcome === 'Pending'


### PR DESCRIPTION
## Summary
- Prevent table rows from expanding when comments are lengthy by truncating note text
- Allow users to view the full note via hover tooltip

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ffe79fdac8323a197f851e5e7f8a2