### PR TITLE
Add truncated previews for bet details

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -134,6 +134,15 @@ td {
   border-bottom: 1px solid #ecf0f1;
 }
 
+.note-cell .note-content,
+.event-cell .event-content,
+.description-cell .description-content {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 tr:hover {
   background-color: #f8f9fa;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -195,9 +195,9 @@ function renderBets() {
     row.innerHTML = `
   <td>${bet.date}</td>
   <td>${bet.sport}</td>
-  <td>${bet.event}</td>
+  <td class="event-cell"><div class="event-content" title="${bet.event}">${bet.event}</div></td>
   <td>${bet.betType}</td>
-  <td>${bet.description || ''}</td>
+  <td class="description-cell"><div class="description-content" title="${bet.description || ''}">${bet.description || ''}</div></td>
   <td>${bet.odds}</td>
   <td>$${bet.stake.toFixed(2)}</td>
   <td>${bet.outcome}</td>
@@ -205,7 +205,7 @@ function renderBets() {
   <td class="${profitClass}">${
     bet.outcome === 'Pending' ? '—' : profitSymbol + '$' + bet.profitLoss.toFixed(2)
   }</td>
-  <td>${bet.note || ''}</td>
+  <td class="note-cell"><div class="note-content" title="${bet.note || ''}">${bet.note || ''}</div></td>
   <td>
     ${
       bet.outcome === 'Pending'

--- a/profile.html
+++ b/profile.html
@@ -222,9 +222,9 @@
         row.innerHTML = `
           <td>${bet.date}</td>
           <td>${bet.sport}</td>
-          <td>${bet.event}</td>
+          <td class="event-cell"><div class="event-content" title="${bet.event}">${bet.event}</div></td>
           <td>${bet.betType}</td>
-          <td>${bet.description || ''}</td>
+          <td class="description-cell"><div class="description-content" title="${bet.description || ''}">${bet.description || ''}</div></td>
           <td>${bet.odds}</td>
           <td>$${bet.stake.toFixed(2)}</td>
           <td>${bet.outcome}</td>
@@ -232,7 +232,7 @@
           <td class="${profitClass}">${
             bet.outcome === 'Pending' ? '—' : profitSymbol + '$' + bet.profitLoss.toFixed(2)
           }</td>
-          <td>${bet.note || ''}</td>
+          <td class="note-cell"><div class="note-content" title="${bet.note || ''}">${bet.note || ''}</div></td>
           <td>
             ${
               bet.outcome === 'Pending'


### PR DESCRIPTION
## Summary
- Apply shared truncation styling for note, event, and description cells to keep rows uniform
- Wrap event and description fields in both tables with ellipsis previews and hover tooltips

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ffe79fdac8323a197f851e5e7f8a2