### PR TITLE
Remove view profile link from header

### DIFF
--- a/shared/header.html
+++ b/shared/header.html
@@ -1,7 +1,4 @@
 <div class="header">
   <h1 id="page-title">🎯 Performance Tracker</h1>
   <p id="page-subtitle">Track your bets meticulously for better bankroll management</p>
-  <nav style="margin-top: 10px;">
-    <a href="profile.html" style="color: white; text-decoration: underline; font-size: 14px;">→ View Profile</a>
-  </nav>
 </div>


### PR DESCRIPTION
## Summary
- remove profile navigation link from shared header

## Testing
- `npm test` (fails: package.json not found)
- `python3 -m http.server` & `curl http://localhost:8000/shared/header.html`

------
https://chatgpt.com/codex/tasks/task_e_689128606cd483238158cff5bc9da571