### PR TITLE
Refine sport selection options

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,13 +26,19 @@
           <label for="sport">Sport</label>
           <select id="sport" required>
             <option value="">Select Sport</option>
-            <option value="Football">Football</option>
-            <option value="Basketball">Basketball</option>
-            <option value="Baseball">Baseball</option>
+            <option value="NFL Football">NFL Football</option>
             <option value="College Football">College Football</option>
-            <option value="Soccer">Soccer</option>
+            <option value="NBA Basketball">NBA Basketball</option>
+            <option value="College Basketball">College Basketball</option>
+            <option value="Baseball">Baseball</option>
+            <option value="Premier League">Premier League</option>
+            <option value="La Liga">La Liga</option>
+            <option value="Bundesliga">Bundesliga</option>
+            <option value="Serie A">Serie A</option>
+            <option value="Ligue 1">Ligue 1</option>
             <option value="Tennis">Tennis</option>
-            <option value="Boxing/MMA">Boxing/MMA</option>
+            <option value="Boxing">Boxing</option>
+            <option value="MMA">MMA</option>
             <option value="Other">Other</option>
           </select>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -29,7 +29,7 @@ function loadDemoData() {
     {
       id: Date.now(),
       date: '2023-09-01',
-      sport: 'Football',
+      sport: 'NFL Football',
       event: 'Team A vs Team B',
       betType: 'Moneyline',
       odds: '+150',
@@ -43,7 +43,7 @@ function loadDemoData() {
     {
       id: Date.now() + 1,
       date: '2023-09-02',
-      sport: 'Basketball',
+      sport: 'NBA Basketball',
       event: 'Team C vs Team D',
       betType: 'Point Spread',
       odds: '-110',


### PR DESCRIPTION
## Summary
- Expand the Sport dropdown to list NFL and college variants, major soccer leagues, and separate Boxing and MMA
- Update demo bet data to match new sport names

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689164a3bd3483239bf0716dd9daff37