### PR TITLE
feat: add header navigation links

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,12 +15,26 @@ body {
   overflow: hidden;
 }
 
-.header {
-  background: linear-gradient(135deg, #2c3e50, #3498db);
-  color: white;
-  padding: 20px;
-  text-align: center;
-}
+  .header {
+    background: linear-gradient(135deg, #2c3e50, #3498db);
+    color: white;
+    padding: 20px;
+    text-align: center;
+    position: relative;
+  }
+
+  .header .top-nav {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+  }
+
+  .header .top-nav a {
+    color: white;
+    text-decoration: underline;
+    font-size: 14px;
+    margin-left: 15px;
+  }
 
 .header h1 {
   margin: 0;

--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -28,11 +28,7 @@ async function loadSharedComponents() {
           headerContainer.insertAdjacentHTML('beforeend', profileHTML);
         }
 
-        // Remove navigation link back to profile since we're already here
-        const profileNav = target.querySelector('nav');
-        if (profileNav) profileNav.remove();
-
-        // Optionally hide default header title/subtitle
+          // Optionally hide default header title/subtitle
         const title = document.getElementById('page-title');
         const subtitle = document.getElementById('page-subtitle');
         if (title) title.style.display = 'none';

--- a/profile.html
+++ b/profile.html
@@ -51,13 +51,6 @@
       color: #e74c3c;
     }
 
-    .header a {
-      color: white;
-      font-size: 13px;
-      text-decoration: underline;
-      margin-top: 8px;
-      display: inline-block;
-    }
   </style>
 </head>
 <body>

--- a/shared/header.html
+++ b/shared/header.html
@@ -1,7 +1,8 @@
 <div class="header">
+  <nav class="top-nav">
+    <a href="index.html">Tracker</a>
+    <a href="profile.html">Learn More</a>
+  </nav>
   <h1 id="page-title">🎯 Performance Tracker</h1>
   <p id="page-subtitle">Track your bets meticulously for better bankroll management</p>
-<nav style="margin-top: 10px;">
-    <a href="profile.html" style="color: white; text-decoration: underline; font-size: 14px;">→ View Profile</a>
-  </nav>
 </div>

--- a/shared/profile-header.html
+++ b/shared/profile-header.html
@@ -8,7 +8,6 @@
       Avg Stake: <span class="highlight" id="profile-avg-stake">$0.00</span> •
       Win Streak: <span class="highlight" id="profile-win-streak">0</span>
     </div>
-    <a href="index.html">← Back to Tracker</a>
-    <button class="btn" onclick="loadDemoData()">Load Demo Bets</button>
+      <button class="btn" onclick="loadDemoData()">Load Demo Bets</button>
+    </div>
   </div>
-</div>


### PR DESCRIPTION
## Summary
- add top-right navigation with tracker and profile links
- style header navigation for proper positioning
- keep navigation in profile view for easy page switching

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917282ac1083238aaa74078d17f781