### PR TITLE
Implement clear all bets functionality

### DIFF
--- a/betting-tracker-backend/routes/bets.js
+++ b/betting-tracker-backend/routes/bets.js
@@ -19,6 +19,12 @@ router.post('/', async (req, res) => {
   }
 });
 
+// Delete all bets
+router.delete('/', async (req, res) => {
+  await Bet.deleteMany({});
+  res.json({ message: 'All bets deleted' });
+});
+
 // Delete a bet
 router.delete('/:id', async (req, res) => {
   await Bet.findByIdAndDelete(req.params.id);

--- a/js/bets.js
+++ b/js/bets.js
@@ -59,6 +59,16 @@ export async function removeBet(betId) {
   }
 }
 
+/** Clear all bets */
+export async function clearBets() {
+  bets = [];
+  try {
+    await fetch(API_URL, { method: 'DELETE' });
+  } catch (err) {
+    console.error('❌ Error clearing bets:', err.message);
+  }
+}
+
 /** Settle a bet by updating its outcome and recalculating */
 export async function settleBet(betId, newOutcome) {
   const bet = bets.find(b => b._id === betId);

--- a/js/form.js
+++ b/js/form.js
@@ -31,7 +31,7 @@ export function updatePayoutPreview() {
   }
 }
 
-export function handleAddBet() {
+export async function handleAddBet() {
   const date = document.getElementById('date').value;
   const sport = document.getElementById('sport').value;
   const event = document.getElementById('event').value;
@@ -77,10 +77,14 @@ export function handleAddBet() {
     note
   };
 
-  addBetData(bet);
-  renderBets();
-  updateStats();
-  clearForm();
+  try {
+    await addBetData(bet);
+    renderBets();
+    updateStats();
+    clearForm();
+  } catch (err) {
+    console.error('❌ Error adding bet:', err.message);
+  }
 }
 
 export function handleClearAll() {


### PR DESCRIPTION
## Summary
- Add `clearBets` utility that wipes local bets and DELETEs `/api/bets`
- Expose new `DELETE /api/bets` backend route to remove all bets from DB
- Ensure form module imports `clearBets` for the Clear All button
- Await `addBet` and re-render so new bets display immediately after submission

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6894458d616c8323954f807529a9f382