### PR TITLE
Fix bet removal and settlement persistence

### DIFF
--- a/betting-tracker-backend/routes/bets.js
+++ b/betting-tracker-backend/routes/bets.js
@@ -25,6 +25,18 @@ router.delete('/', async (req, res) => {
   res.json({ message: 'All bets deleted' });
 });
 
+// Update a bet
+router.put('/:id', async (req, res) => {
+  try {
+    const updatedBet = await Bet.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+    });
+    res.json(updatedBet);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 // Delete a bet
 router.delete('/:id', async (req, res) => {
   await Bet.findByIdAndDelete(req.params.id);

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,7 @@ import { showFullText, closeModal } from './modal.js';
 // Always make core functions globally available for buttons
 window.addBet = handleAddBet;
 window.clearAllBets = handleClearAll;
+window.removeBet = handleRemoveBet;
 window.loadDemoData = async () => {
   loadDemoBets();
   renderBets();

--- a/js/form.js
+++ b/js/form.js
@@ -87,9 +87,9 @@ export async function handleAddBet() {
   }
 }
 
-export function handleClearAll() {
+export async function handleClearAll() {
   if (confirm('Are you sure you want to clear all betting data? This cannot be undone.')) {
-    clearBets();
+    await clearBets();
     renderBets();
     updateStats();
   }

--- a/js/render.js
+++ b/js/render.js
@@ -1,16 +1,16 @@
 import { bets, removeBet as removeBetData, settleBet as settleBetData } from './bets.js';
 import { updateStats } from './stats.js';
 
-export function handleRemoveBet(id) {
-  removeBetData(id);
+export async function handleRemoveBet(id) {
+  await removeBetData(id);
   renderBets();
   updateStats();
 }
 
-export function handleSettleBet(selectEl, betId) {
+export async function handleSettleBet(selectEl, betId) {
   const newOutcome = selectEl.value;
   if (!newOutcome) return;
-  settleBetData(betId, newOutcome);
+  await settleBetData(betId, newOutcome);
   renderBets();
   updateStats();
 }


### PR DESCRIPTION
## Summary
- expose removeBet handler and await async bet mutations for reliable UI updates
- make Clear All wait for server deletion before rerendering
- add backend route to update bets so settled bets persist

## Testing
- `npm test --prefix betting-tracker-backend` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_6894dca698ac8323a382eee95d2ae282