### PR TITLE
Expose renderBets globally

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -17,6 +17,7 @@ window.settleBet = handleSettleBet;
 window.showFullText = showFullText;
 window.closeModal = closeModal;
 window.exportToCSV = exportToCSV;
+window.renderBets = renderBets;
 
 // Initialize form handlers
 initForm();


### PR DESCRIPTION
## Summary
- make renderBets globally accessible so sort controls update the bet list

## Testing
- `npm test --prefix betting-tracker-backend` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689597079b9883239d7a6c488b9ceac7