### PR TITLE
Format dates as MM-DD-YYYY

### DIFF
--- a/js/bets.js
+++ b/js/bets.js
@@ -1,3 +1,4 @@
+import { formatDate } from './utils.js';
 export let bets = [];
 
 const API_URL = 'http://localhost:5000/api/bets'; // Change to your deployed URL in production
@@ -108,7 +109,7 @@ export function exportToCSV() {
   const csvContent = [
     headers.join(','),
     ...bets.map(bet => [
-      bet.date,
+      formatDate(bet.date),
       bet.sport,
       bet.event,
       bet.betType,

--- a/js/render.js
+++ b/js/render.js
@@ -1,5 +1,6 @@
 import { bets, removeBet as removeBetData, settleBet as settleBetData } from './bets.js';
 import { updateStats } from './stats.js';
+import { formatDate } from './utils.js';
 
 export async function handleRemoveBet(id) {
   await removeBetData(id);
@@ -51,7 +52,7 @@ export function renderBets() {
     const profitSymbol = bet.profitLoss > 0 ? '+' : '';
 
     row.innerHTML = `
-      <td>${bet.date}</td>
+      <td>${formatDate(bet.date)}</td>
       <td>${bet.sport}</td>
       <td class="event-cell">
         <div class="event-content" title="${bet.event}" onclick="showFullText(${JSON.stringify(bet.event)})">

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,0 +1,7 @@
+export function formatDate(dateStr) {
+  const date = new Date(dateStr);
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const year = date.getUTCFullYear();
+  return `${month}-${day}-${year}`;
+}


### PR DESCRIPTION
## Summary
- Format bet dates as MM-DD-YYYY in table rendering
- Add date formatting utility and apply to CSV export

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895988abbf083238c1e5fbcfb96cfdc