### PR TITLE
Add JWT auth middleware and protect bets routes

### DIFF
--- a/betting-tracker-backend/middleware/auth.js
+++ b/betting-tracker-backend/middleware/auth.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function (req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ error: 'No token provided' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(403).json({ error: 'Invalid token' });
+  }
+};

--- a/betting-tracker-backend/package.json
+++ b/betting-tracker-backend/package.json
@@ -15,7 +15,8 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
-    "mongoose": "^8.17.0"
+    "mongoose": "^8.17.0",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
 require('dotenv').config();
+const auth = require('./middleware/auth');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -25,7 +26,7 @@ app.get('/', (req, res) => {
 
 // Routes
 const betRoutes = require('./routes/bets');
-app.use('/api/bets', betRoutes);
+app.use('/api/bets', auth, betRoutes);
 
 // Start server
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- add JSON Web Token authentication middleware
- restrict `/api/bets` routes to authenticated users
- include jsonwebtoken dependency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896258ec1708323b02f86e58ec23656