### PR TITLE
Add login and registration pages with JWT auth

### DIFF
--- a/js/bets.js
+++ b/js/bets.js
@@ -3,10 +3,15 @@ export let bets = [];
 
 const API_URL = 'http://localhost:5000/api/bets'; // Change to your deployed URL in production
 
+function authHeaders(extra = {}) {
+  const token = localStorage.getItem('token');
+  return token ? { ...extra, Authorization: `Bearer ${token}` } : { ...extra };
+}
+
 /** Fetch all bets from the backend */
 export async function fetchBets() {
   try {
-    const res = await fetch(API_URL);
+    const res = await fetch(API_URL, { headers: authHeaders() });
     if (!res.ok) throw new Error('Failed to fetch bets');
     bets = await res.json();
   } catch (err) {
@@ -38,7 +43,7 @@ export async function addBet(bet) {
   try {
     const res = await fetch(API_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(bet),
     });
     const savedBet = await res.json();
@@ -53,6 +58,7 @@ export async function removeBet(betId) {
   try {
     await fetch(`${API_URL}/${betId}`, {
       method: 'DELETE',
+      headers: authHeaders(),
     });
     bets = bets.filter(b => b._id !== betId);
   } catch (err) {
@@ -64,7 +70,7 @@ export async function removeBet(betId) {
 export async function clearBets() {
   bets = [];
   try {
-    await fetch(API_URL, { method: 'DELETE' });
+    await fetch(API_URL, { method: 'DELETE', headers: authHeaders() });
   } catch (err) {
     console.error('❌ Error clearing bets:', err.message);
   }
@@ -88,7 +94,7 @@ export async function settleBet(betId, newOutcome) {
   try {
     const res = await fetch(`${API_URL}/${betId}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
+      headers: authHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(bet),
     });
 

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,22 @@
+document.getElementById('login-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value;
+
+  try {
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+
+    if (!res.ok) throw new Error('Login failed');
+
+    const data = await res.json();
+    localStorage.setItem('token', data.token);
+    window.location.href = 'index.html';
+  } catch (err) {
+    console.error('❌ Login error:', err.message);
+    alert('Login failed. Please check your credentials.');
+  }
+});

--- a/js/register.js
+++ b/js/register.js
@@ -1,0 +1,22 @@
+document.getElementById('register-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value.trim();
+  const password = document.getElementById('password').value;
+
+  try {
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+
+    if (!res.ok) throw new Error('Registration failed');
+
+    const data = await res.json();
+    localStorage.setItem('token', data.token);
+    window.location.href = 'index.html';
+  } catch (err) {
+    console.error('❌ Registration error:', err.message);
+    alert('Registration failed. Please try again.');
+  }
+});

--- a/login.html
+++ b/login.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Login</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="container">
+    <div id="include-header"></div>
+    <div class="controls">
+      <h2>Login</h2>
+      <form id="login-form">
+        <div class="form-row">
+          <div class="form-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" required />
+          </div>
+        </div>
+        <button class="btn" type="submit">Login</button>
+      </form>
+    </div>
+  </div>
+  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/login.js"></script>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Register</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="container">
+    <div id="include-header"></div>
+    <div class="controls">
+      <h2>Register</h2>
+      <form id="register-form">
+        <div class="form-row">
+          <div class="form-group">
+            <label for="username">Username</label>
+            <input type="text" id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" required />
+          </div>
+        </div>
+        <button class="btn" type="submit">Register</button>
+      </form>
+    </div>
+  </div>
+  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/register.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add login and registration pages with credential forms and modules
- Store JWT in localStorage and use Authorization headers for bet API calls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962677d7588323995a7fa23795975c