### PR TITLE
Add basic user authentication routes

### DIFF
--- a/betting-tracker-backend/.env
+++ b/betting-tracker-backend/.env
@@ -1,2 +1,3 @@
 MONGO_URI=mongodb+srv://amarubenj17:AwRxV3aM4h2E7ONK@moneylineplayers.wx2jkww.mongodb.net/betting?retryWrites=true&w=majority&appName=Moneylineplayers
 PORT=5000
+JWT_SECRET=your_jwt_secret

--- a/betting-tracker-backend/models/User.js
+++ b/betting-tracker-backend/models/User.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const UserSchema = new mongoose.Schema({
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+});
+
+module.exports = mongoose.model('User', UserSchema);

--- a/betting-tracker-backend/package.json
+++ b/betting-tracker-backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcrypt": "^5.1.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/betting-tracker-backend/routes/auth.js
+++ b/betting-tracker-backend/routes/auth.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const User = require('../models/User');
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  try {
+    const { username, password } = req.body;
+    if (!username || !password) {
+      return res.status(400).json({ error: 'Username and password are required' });
+    }
+    let user = await User.findOne({ username });
+    if (user) {
+      return res.status(400).json({ error: 'User already exists' });
+    }
+    const hashedPassword = await bcrypt.hash(password, 10);
+    user = new User({ username, password: hashedPassword });
+    await user.save();
+    const token = jwt.sign({ id: user._id, username: user.username }, process.env.JWT_SECRET);
+    res.status(201).json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const { username, password } = req.body;
+    const user = await User.findOne({ username });
+    if (!user) {
+      return res.status(400).json({ error: 'Invalid credentials' });
+    }
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ id: user._id, username: user.username }, process.env.JWT_SECRET);
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -26,6 +26,7 @@ app.get('/', (req, res) => {
 
 // Routes
 const betRoutes = require('./routes/bets');
+app.use('/api/auth', require('./routes/auth'));
 app.use('/api/bets', auth, betRoutes);
 
 // Start server


### PR DESCRIPTION
## Summary
- add User model to store usernames and hashed passwords
- implement auth register/login routes issuing JWTs
- mount auth router in server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689772cfb0d4832385e12b9dad059b75