### PR TITLE
refactor: centralize API base URL

### DIFF
--- a/js/bets.js
+++ b/js/bets.js
@@ -1,7 +1,8 @@
 import { formatDate } from './utils.js';
+import { API_BASE_URL } from './config.js';
 export let bets = [];
 
-const API_URL = 'http://localhost:5000/api/bets'; // Change to your deployed URL in production
+const API_URL = `${API_BASE_URL}/api/bets`;
 
 function authHeaders(extra = {}) {
   const token = localStorage.getItem('token');

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = window.API_BASE_URL || 'http://localhost:5000';

--- a/js/login.js
+++ b/js/login.js
@@ -1,10 +1,12 @@
+import { API_BASE_URL } from './config.js';
+
 document.getElementById('login-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = document.getElementById('username').value.trim();
   const password = document.getElementById('password').value;
 
   try {
-    const res = await fetch('/api/auth/login', {
+    const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })

--- a/js/register.js
+++ b/js/register.js
@@ -1,10 +1,12 @@
+import { API_BASE_URL } from './config.js';
+
 document.getElementById('register-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = document.getElementById('username').value.trim();
   const password = document.getElementById('password').value;
 
   try {
-    const res = await fetch('/api/auth/register', {
+    const res = await fetch(`${API_BASE_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })


### PR DESCRIPTION
## Summary
- add configurable `API_BASE_URL`
- use `API_BASE_URL` for auth and bets API calls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898eab213a08323857a4aaefe8ffcd9