### PR TITLE
Display active username in UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,6 +38,12 @@ body {
     margin-left: 15px;
   }
 
+  .header .top-nav .user-display {
+    color: white;
+    font-size: 14px;
+    margin-left: 15px;
+  }
+
  .header .learn-more-link {
     color: white;
     text-decoration: underline;

--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -1,3 +1,25 @@
+function getUsername() {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  try {
+    return JSON.parse(atob(token.split('.')[1])).username;
+  } catch {
+    return null;
+  }
+}
+
+function applyUsername(container, username) {
+  if (!username) return;
+  const userDisplay = container.querySelector('#current-user');
+  if (userDisplay) userDisplay.textContent = username;
+
+  const profileName = container.querySelector('#profile-username');
+  if (profileName) profileName.textContent = username;
+
+  const avatar = container.querySelector('.profile-avatar');
+  if (avatar) avatar.textContent = username.slice(0, 2).toUpperCase();
+}
+
 async function loadSharedComponents() {
   const includes = {
     header: 'shared/header.html',
@@ -17,6 +39,9 @@ async function loadSharedComponents() {
       const html = await res.text();
       target.innerHTML = html;
 
+      const username = getUsername();
+      applyUsername(target, username);
+
       // Profile-specific behavior
       if (key === 'header' && window.location.pathname.includes('profile.html')) {
         const profileRes = await fetch('shared/profile-header.html');
@@ -26,9 +51,10 @@ async function loadSharedComponents() {
         const headerContainer = target.querySelector('.header');
         if (headerContainer) {
           headerContainer.insertAdjacentHTML('beforeend', profileHTML);
+          applyUsername(headerContainer, username);
         }
 
-          // Optionally hide default header title/subtitle
+        // Optionally hide default header title/subtitle
         const title = document.getElementById('page-title');
         const subtitle = document.getElementById('page-subtitle');
         const learnMore = document.getElementById('learn-more-link');

--- a/shared/header.html
+++ b/shared/header.html
@@ -3,6 +3,7 @@
     <a href="index.html">Tracker</a>
     <a href="profile.html">Profile</a>
     <a href="settings.html">Settings</a>
+    <span id="current-user" class="user-display"></span>
   </nav>
   <h1 id="page-title">🎯 Performance Tracker</h1>
   <p id="page-subtitle">Track your bets meticulously for better bankroll management</p>

--- a/shared/profile-header.html
+++ b/shared/profile-header.html
@@ -1,7 +1,7 @@
 <div class="profile-header-container">
   <div class="profile-avatar">BT</div>
   <div>
-    <h1>👤 Betting Profile</h1>
+    <h1>👤 <span id="profile-username">Betting Profile</span></h1>
     <p>Member since today • <span id="profile-total-bets">0</span> total bets</p>
     <div class="profile-header-insights">
       Most Profitable: <span class="highlight" id="profile-best-sport">-</span> •


### PR DESCRIPTION
## Summary
- Show logged-in user's name in navigation header
- Render username in profile header and avatar
- Decode JWT token on load to populate user details

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd betting-tracker-backend && npm test)` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898e8f06058832387b589e0897582c6