### PR TITLE
refactor: centralize API base URL

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -1,0 +1,25 @@
+// Simple auth state handling for UI
+function updateAuthUI() {
+  const loginBtn = document.getElementById('login-btn');
+  const signupBtn = document.getElementById('signup-btn');
+  const logoutBtn = document.getElementById('logout-btn');
+
+  const token = localStorage.getItem('token');
+  const isLoggedIn = Boolean(token);
+
+  if (isLoggedIn) {
+    if (loginBtn) loginBtn.style.display = 'none';
+    if (signupBtn) signupBtn.style.display = 'none';
+    if (logoutBtn) {
+      logoutBtn.style.display = 'inline-block';
+      logoutBtn.addEventListener('click', () => {
+        localStorage.removeItem('token');
+        location.reload();
+      }, { once: true });
+    }
+  } else {
+    if (logoutBtn) logoutBtn.style.display = 'none';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', updateAuthUI);

--- a/js/bets.js
+++ b/js/bets.js
@@ -1,7 +1,8 @@
 import { formatDate } from './utils.js';
+import { API_BASE_URL } from './config.js';
 export let bets = [];
 
-const API_URL = 'http://localhost:5000/api/bets'; // Change to your deployed URL in production
+const API_URL = `${API_BASE_URL}/api/bets`;
 
 function authHeaders(extra = {}) {
   const token = localStorage.getItem('token');

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = window.API_BASE_URL || 'http://localhost:5000';

--- a/js/login.js
+++ b/js/login.js
@@ -1,10 +1,12 @@
+import { API_BASE_URL } from './config.js';
+
 document.getElementById('login-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = document.getElementById('username').value.trim();
   const password = document.getElementById('password').value;
 
   try {
-    const res = await fetch('/api/auth/login', {
+    const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })

--- a/js/register.js
+++ b/js/register.js
@@ -1,10 +1,12 @@
+import { API_BASE_URL } from './config.js';
+
 document.getElementById('register-form').addEventListener('submit', async (e) => {
   e.preventDefault();
   const username = document.getElementById('username').value.trim();
   const password = document.getElementById('password').value;
 
   try {
-    const res = await fetch('/api/auth/register', {
+    const res = await fetch(`${API_BASE_URL}/api/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })

--- a/settings.html
+++ b/settings.html
@@ -16,14 +16,16 @@
         <button class="btn btn-danger" onclick="clearAllBets()">Clear All Bets</button>
         <div class="auth-controls">
           <h3>Account</h3>
-          <a href="login.html" class="btn">Log In</a>
-          <a href="register.html" class="btn">Sign Up</a>
+          <a href="login.html" class="btn" id="login-btn">Log In</a>
+          <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
+          <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
         </div>
       </div>
     </div>
 
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
+  <script src="js/auth.js"></script>
   <script>
     window.addEventListener('shared:loaded', () => {
       const title = document.getElementById('page-title');


### PR DESCRIPTION
## Summary
- add configurable `API_BASE_URL`
- use `API_BASE_URL` for auth and bets API calls
- toggle settings auth controls based on login state

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6898eab213a08323857a4aaefe8ffcd9