### PR TITLE
Add admin panel to list registered users

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Admin Panel</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="container">
+    <div id="include-header"></div>
+    <h2>User List</h2>
+    <ul id="user-list"></ul>
+  </div>
+  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/admin.js"></script>
+</body>
+</html>

--- a/betting-tracker-backend/routes/users.js
+++ b/betting-tracker-backend/routes/users.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const User = require('../models/User');
+
+const router = express.Router();
+
+// Get all registered users (admin access)
+router.get('/', async (req, res) => {
+  try {
+    const users = await User.find().select('username');
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -26,8 +26,10 @@ app.get('/', (req, res) => {
 
 // Routes
 const betRoutes = require('./routes/bets');
+const userRoutes = require('./routes/users');
 app.use('/api/auth', require('./routes/auth'));
 app.use('/api/bets', auth, betRoutes);
+app.use('/api/users', auth, userRoutes);
 
 // Start server
 app.listen(PORT, () => {

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,20 @@
+import { API_BASE_URL } from './config.js';
+
+async function loadUsers() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/users`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error('Failed to fetch users');
+    const users = await res.json();
+    const list = document.getElementById('user-list');
+    list.innerHTML = users.map(u => `<li>${u.username}</li>`).join('');
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+window.addEventListener('shared:loaded', loadUsers);

--- a/shared/header.html
+++ b/shared/header.html
@@ -3,6 +3,7 @@
     <a href="index.html">Tracker</a>
     <a href="profile.html">Profile</a>
     <a href="settings.html">Settings</a>
+    <a href="admin.html">Admin</a>
     <span id="current-user" class="user-display"></span>
   </nav>
   <h1 id="page-title">🎯 Performance Tracker</h1>


### PR DESCRIPTION
## Summary
- Add `/api/users` route to fetch registered users
- Wire up admin page and script to show user list
- Include navigation link for admin panel

## Testing
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6898fb510c3c8323aa2f52162ed1d5d8