### PR TITLE
feat: add admin role authorization

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <div id="include-header"></div>
-    <h2>User List</h2>
+    <h2 id="user-count-header">Total Users: 0</h2>
     <ul id="user-list"></ul>
   </div>
   <script src="js/loadShared.js"></script>

--- a/betting-tracker-backend/middleware/authorize.js
+++ b/betting-tracker-backend/middleware/authorize.js
@@ -1,0 +1,8 @@
+module.exports = function(...allowedRoles) {
+  return (req, res, next) => {
+    if (!req.user || !allowedRoles.includes(req.user.role)) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+    next();
+  };
+};

--- a/betting-tracker-backend/models/User.js
+++ b/betting-tracker-backend/models/User.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const UserSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   password: { type: String, required: true },
+  role: { type: String, enum: ['user', 'admin'], default: 'user' }
 });
 
 module.exports = mongoose.model('User', UserSchema);

--- a/betting-tracker-backend/routes/auth.js
+++ b/betting-tracker-backend/routes/auth.js
@@ -7,7 +7,7 @@ const router = express.Router();
 
 router.post('/register', async (req, res) => {
   try {
-    const { username, password } = req.body;
+    const { username, password, role } = req.body;
     if (!username || !password) {
       return res.status(400).json({ error: 'Username and password are required' });
     }
@@ -16,9 +16,9 @@ router.post('/register', async (req, res) => {
       return res.status(400).json({ error: 'User already exists' });
     }
     const hashedPassword = await bcrypt.hash(password, 10);
-    user = new User({ username, password: hashedPassword });
+    user = new User({ username, password: hashedPassword, role: role || 'user' });
     await user.save();
-    const token = jwt.sign({ id: user._id, username: user.username }, process.env.JWT_SECRET);
+    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
     res.status(201).json({ token });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -36,7 +36,7 @@ router.post('/login', async (req, res) => {
     if (!isMatch) {
       return res.status(400).json({ error: 'Invalid credentials' });
     }
-    const token = jwt.sign({ id: user._id, username: user.username }, process.env.JWT_SECRET);
+    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
     res.json({ token });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/betting-tracker-backend/routes/users.js
+++ b/betting-tracker-backend/routes/users.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const User = require('../models/User');
+const authorize = require('../middleware/authorize');
 
 const router = express.Router();
 
 // Get all registered users (admin access)
-router.get('/', async (req, res) => {
+router.get('/', authorize('admin'), async (req, res) => {
   try {
     const users = await User.find().select('username');
     res.json(users);

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,14 +1,22 @@
 import { API_BASE_URL } from './config.js';
-
+import { decodeToken } from './utils.js';
 
 const API_URL = `${API_BASE_URL}/api/users`;
 
 async function loadUsers() {
   const token = localStorage.getItem('token');
-  if (!token) return;
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+
+  const user = decodeToken(token);
+  if (!user || user.role !== 'admin') {
+    window.location.href = 'index.html';
+    return;
+  }
 
   try {
-
     const res = await fetch(API_URL, {
       headers: { Authorization: `Bearer ${token}` }
     });
@@ -16,6 +24,7 @@ async function loadUsers() {
     const users = await res.json();
     const list = document.getElementById('user-list');
     list.innerHTML = users.map(u => `<li>${u.username}</li>`).join('');
+    document.getElementById('user-count-header').textContent = `Total Users: ${users.length}`;
   } catch (err) {
     console.error(err);
   }

--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -1,8 +1,8 @@
-function getUsername() {
+function getUser() {
   const token = localStorage.getItem('token');
   if (!token) return null;
   try {
-    return JSON.parse(atob(token.split('.')[1])).username;
+    return JSON.parse(atob(token.split('.')[1]));
   } catch {
     return null;
   }
@@ -39,8 +39,15 @@ async function loadSharedComponents() {
       const html = await res.text();
       target.innerHTML = html;
 
-      const username = getUsername();
-      applyUsername(target, username);
+      const user = getUser();
+      applyUsername(target, user?.username);
+
+      if (key === 'header') {
+        const adminLink = target.querySelector('a[href="admin.html"]');
+        if (adminLink && user?.role !== 'admin') {
+          adminLink.style.display = 'none';
+        }
+      }
 
       // Profile-specific behavior
       if (key === 'header' && window.location.pathname.includes('profile.html')) {
@@ -51,7 +58,7 @@ async function loadSharedComponents() {
         const headerContainer = target.querySelector('.header');
         if (headerContainer) {
           headerContainer.insertAdjacentHTML('beforeend', profileHTML);
-          applyUsername(headerContainer, username);
+          applyUsername(headerContainer, user?.username);
         }
 
         // Optionally hide default header title/subtitle

--- a/js/utils.js
+++ b/js/utils.js
@@ -5,3 +5,11 @@ export function formatDate(dateStr) {
   const year = date.getUTCFullYear();
   return `${month}-${day}-${year}`;
 }
+
+export function decodeToken(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add role property to users and sign JWTs with role
- create middleware to guard admin-only routes
- enforce admin role in frontend and hide admin link for non-admin users
- show total user count in admin panel header

## Testing
- `npm test --prefix betting-tracker-backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a6c6a150c83239777cc4df1e14b49