### PR TITLE
chore: use origin for api base url

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,1 +1,1 @@
-export const API_BASE_URL = window.API_BASE_URL || 'http://localhost:5000';
+export const API_BASE_URL = window.API_BASE_URL || window.location.origin;


### PR DESCRIPTION
## Summary
- default API base URL to `window.location.origin`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8e777f588323a303041aaa925bbd