### PR TITLE
Add Vercel auth functions with shared Mongo connection

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,0 +1,32 @@
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const dbConnect = require('../../lib/mongo');
+const User = require('../../betting-tracker-backend/models/User');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  await dbConnect();
+
+  try {
+    const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+    const { username, password } = body || {};
+    const user = await User.findOne({ username });
+    if (!user) {
+      return res.status(400).json({ error: 'Invalid credentials' });
+    }
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign(
+      { id: user._id, username: user.username, role: user.role },
+      process.env.JWT_SECRET
+    );
+    res.status(200).json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -1,0 +1,35 @@
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const dbConnect = require('../../lib/mongo');
+const User = require('../../betting-tracker-backend/models/User');
+
+module.exports = async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  await dbConnect();
+
+  try {
+    const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+    const { username, password, role } = body || {};
+    if (!username || !password) {
+      return res.status(400).json({ error: 'Username and password are required' });
+    }
+
+    let user = await User.findOne({ username });
+    if (user) {
+      return res.status(400).json({ error: 'User already exists' });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+    user = await User.create({ username, password: hashedPassword, role: role || 'user' });
+    const token = jwt.sign(
+      { id: user._id, username: user.username, role: user.role },
+      process.env.JWT_SECRET
+    );
+    res.status(201).json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+
+let cached = global.mongoose;
+
+if (!cached) {
+  cached = global.mongoose = { conn: null, promise: null };
+}
+
+async function dbConnect() {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    const uri = process.env.MONGO_URI;
+    if (!uri) {
+      throw new Error('MONGO_URI is not defined');
+    }
+    const opts = { bufferCommands: false };
+    cached.promise = mongoose.connect(uri, opts).then((mongoose) => mongoose);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}
+
+module.exports = dbConnect;


### PR DESCRIPTION
## Summary
- add MongoDB connection helper that caches the mongoose connection
- create `login` and `register` serverless functions reusing existing auth logic

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd betting-tracker-backend && npm test)` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689aa026fd6083238c5b9da88fabd662