### PR TITLE
feat: configure API base URL via env

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,1 +1,3 @@
-export const API_BASE_URL = 'https://betting-tracker-nine.vercel.app' || 'http://localhost:5000';
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");


### PR DESCRIPTION
## Summary
- make API base URL dynamic from env variable with default fallback

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689aa14c89f48323b52cfe263a7b7f6b