### PR TITLE
Refactor MongoDB connection helper for API routes

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-const dbConnect = require('../../lib/mongo');
+const connectToDatabase = require('../../lib/mongo');
 const User = require('../../betting-tracker-backend/models/User');
 
 module.exports = async function handler(req, res) {
@@ -8,7 +8,7 @@ module.exports = async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  await dbConnect();
+  await connectToDatabase();
 
   try {
     const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;

--- a/api/auth/register.js
+++ b/api/auth/register.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
-const dbConnect = require('../../lib/mongo');
+const connectToDatabase = require('../../lib/mongo');
 const User = require('../../betting-tracker-backend/models/User');
 
 module.exports = async function handler(req, res) {
@@ -8,7 +8,7 @@ module.exports = async function handler(req, res) {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  await dbConnect();
+  await connectToDatabase();
 
   try {
     const body = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -6,7 +6,7 @@ if (!cached) {
   cached = global.mongoose = { conn: null, promise: null };
 }
 
-async function dbConnect() {
+async function connectToDatabase() {
   if (cached.conn) return cached.conn;
   if (!cached.promise) {
     const uri = process.env.MONGO_URI;
@@ -20,4 +20,4 @@ async function dbConnect() {
   return cached.conn;
 }
 
-module.exports = dbConnect;
+module.exports = connectToDatabase;


### PR DESCRIPTION
## Summary
- add `connectToDatabase` helper that caches the mongoose connection
- use `connectToDatabase` in auth login and register API routes

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689aa1ebae348323b81ce2f99c5e93cc