### PR TITLE
refactor: use window API base URL

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -13,6 +13,9 @@
     <ul id="user-list"></ul>
   </div>
   <script src="js/loadShared.js"></script>
+  <script>
+    window.API_BASE_URL = window.API_BASE_URL || window.location.origin;
+  </script>
   <script type="module" src="js/admin.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -120,6 +120,9 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
+  <script>
+    window.API_BASE_URL = window.API_BASE_URL || window.location.origin;
+  </script>
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
 </body>

--- a/js/config.js
+++ b/js/config.js
@@ -1,3 +1,3 @@
 export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_BASE_URL ||
-  (typeof window !== "undefined" ? window.location.origin : "http://localhost:3000");
+  (typeof window !== "undefined" && window.API_BASE_URL) ||
+  window.location.origin;

--- a/login.html
+++ b/login.html
@@ -27,6 +27,9 @@
     </div>
   </div>
   <script src="js/loadShared.js"></script>
+  <script>
+    window.API_BASE_URL = window.API_BASE_URL || window.location.origin;
+  </script>
   <script type="module" src="js/login.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -71,6 +71,9 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
+  <script>
+    window.API_BASE_URL = window.API_BASE_URL || window.location.origin;
+  </script>
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
 </body>

--- a/register.html
+++ b/register.html
@@ -27,6 +27,9 @@
     </div>
   </div>
   <script src="js/loadShared.js"></script>
+  <script>
+    window.API_BASE_URL = window.API_BASE_URL || window.location.origin;
+  </script>
   <script type="module" src="js/register.js"></script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -23,6 +23,9 @@
       </div>
     </div>
 
+  <script>
+    window.API_BASE_URL = window.API_BASE_URL || window.location.origin;
+  </script>
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
   <script src="js/auth.js"></script>


### PR DESCRIPTION
## Summary
- remove direct `process.env` reference in API config
- expose `window.API_BASE_URL` across HTML pages and read it from `config.js`

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aa38528488323a3951298d091add6