### PR TITLE
Add API package manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Betting Tracker
+
+This project includes API handlers under the `api/` directory. To run them
+locally or deploy them, install the runtime dependencies and ensure that the
+generated `node_modules` directory is bundled with your deployment.
+
+```bash
+npm install
+```
+
+The APIs rely on packages such as `bcrypt`, `jsonwebtoken`, `mongoose`, and
+`dotenv`.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "betting-tracker",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "betting-tracker",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "bcrypt": "^5.1.0",
+        "dotenv": "^17.2.1",
+        "jsonwebtoken": "^9.0.2",
+        "mongoose": "^8.17.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "betting-tracker",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcrypt": "^5.1.0",
+    "dotenv": "^17.2.1",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.17.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with bcrypt, jsonwebtoken, mongoose, and dotenv
- note dependency installation requirement in README

## Testing
- `npm install bcrypt@^5.1.0 jsonwebtoken@^9.0.2 mongoose@^8.17.0 dotenv@^17.2.1` *(fails: 403 Forbidden)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689aa97b82d08323a1f64f86fe138719