### PR TITLE
Add Vercel serverless backend for Express API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env.local

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,2 @@
+import app from '../src/app.js';
+export default app;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "betting-tracker",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vercel dev",
+    "start": "node api/index.js",
+    "test": "echo \"No tests\""
+  },
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "mongoose": "^8.6.0"
+  },
+  "devDependencies": {
+    "@vercel/node": "^3.2.0"
+  }
+}

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import cors from 'cors';
+import cookieParser from 'cookie-parser';
+import authRouter from './routes/auth.js';
+import betRoutes from './routes/bets.js';
+import userRoutes from './routes/users.js';
+import auth from './middleware/auth.js';
+import connectDB from './db.js';
+
+const app = express();
+
+app.use(express.json());
+app.use(cookieParser());
+
+const allowed = [
+  'https://your-frontend.vercel.app'
+];
+app.use(cors({ origin: allowed, credentials: true }));
+
+await connectDB();
+
+app.use('/auth', authRouter);
+app.use('/bets', auth, betRoutes);
+app.use('/users', auth, userRoutes);
+
+app.get('/health', (_, res) => res.json({ ok: true }));
+
+export default app;

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,15 @@
+import mongoose from 'mongoose';
+
+let cached = global._mongoose;
+if (!cached) cached = global._mongoose = { conn: null, promise: null };
+
+export default async function connectDB() {
+  if (cached.conn) return cached.conn;
+  if (!cached.promise) {
+    const uri = process.env.MONGO_URI;
+    if (!uri) throw new Error('Missing MONGO_URI');
+    cached.promise = mongoose.connect(uri, { bufferCommands: false }).then((m) => m);
+  }
+  cached.conn = await cached.promise;
+  return cached.conn;
+}

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,16 @@
+import jwt from 'jsonwebtoken';
+
+export default function (req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ error: 'No token provided' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    next();
+  } catch (err) {
+    res.status(403).json({ error: 'Invalid token' });
+  }
+}

--- a/src/middleware/authorize.js
+++ b/src/middleware/authorize.js
@@ -1,0 +1,8 @@
+export default function (...allowedRoles) {
+  return (req, res, next) => {
+    if (!req.user || !allowedRoles.includes(req.user.role)) {
+      return res.status(403).json({ error: 'Access denied' });
+    }
+    next();
+  };
+}

--- a/src/models/Bet.js
+++ b/src/models/Bet.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const BetSchema = new mongoose.Schema({
+  date: String,
+  sport: String,
+  event: String,
+  betType: String,
+  odds: String,
+  stake: Number,
+  outcome: String,
+  payout: Number,
+  profitLoss: Number,
+  description: String,
+  note: String,
+});
+
+export default mongoose.model('Bet', BetSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+
+const UserSchema = new mongoose.Schema({
+  username: { type: String, required: true, unique: true },
+  password: { type: String, required: true },
+  role: { type: String, enum: ['user', 'admin'], default: 'user' }
+});
+
+export default mongoose.model('User', UserSchema);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,0 +1,46 @@
+import { Router } from 'express';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import User from '../models/User.js';
+
+const router = Router();
+
+router.post('/register', async (req, res) => {
+  try {
+    const { username, password, role } = req.body;
+    if (!username || !password) {
+      return res.status(400).json({ error: 'Username and password are required' });
+    }
+    let user = await User.findOne({ username });
+    if (user) {
+      return res.status(400).json({ error: 'User already exists' });
+    }
+    const hashedPassword = await bcrypt.hash(password, 10);
+    user = new User({ username, password: hashedPassword, role: role || 'user' });
+    await user.save();
+    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
+    res.status(201).json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  try {
+    const { username, password } = req.body;
+    const user = await User.findOne({ username });
+    if (!user) {
+      return res.status(400).json({ error: 'Invalid credentials' });
+    }
+    const isMatch = await bcrypt.compare(password, user.password);
+    if (!isMatch) {
+      return res.status(400).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import Bet from '../models/Bet.js';
+
+const router = Router();
+
+router.get('/', async (req, res) => {
+  const bets = await Bet.find();
+  res.json(bets);
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const newBet = new Bet(req.body);
+    await newBet.save();
+    res.status(201).json(newBet);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/', async (req, res) => {
+  await Bet.deleteMany({});
+  res.json({ message: 'All bets deleted' });
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const updatedBet = await Bet.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    res.json(updatedBet);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  await Bet.findByIdAndDelete(req.params.id);
+  res.json({ message: 'Bet deleted' });
+});
+
+export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import User from '../models/User.js';
+import authorize from '../middleware/authorize.js';
+
+const router = Router();
+
+router.get('/', authorize('admin'), async (req, res) => {
+  try {
+    const users = await User.find().select('username');
+    res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+export default router;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "api/index.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add serverless entrypoint and Express app structure for Vercel deployment
- connect to MongoDB with cached connection and expose auth, bet, and user routes
- configure project metadata for serverless functions

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vercel%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_689ba1ac998c8323bf286712a7755084