### PR TITLE
feat: point frontend to live backend API

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -12,6 +12,11 @@
     <h2 id="user-count-header">Total Users: 0</h2>
     <ul id="user-list"></ul>
   </div>
+  <!-- Set this to your live backend in production -->
+  <script>
+    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
+  </script>
+
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -120,6 +120,11 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
+  <!-- Set this to your live backend in production -->
+  <script>
+    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
+  </script>
+
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
 </body>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,7 +1,7 @@
 import { API_BASE_URL } from './config.js';
 import { decodeToken } from './utils.js';
 
-const API_URL = `${API_BASE_URL}/api/users`;
+const API_URL = `${API_BASE_URL}/users`;
 
 async function loadUsers() {
   const token = localStorage.getItem('token');

--- a/js/bets.js
+++ b/js/bets.js
@@ -2,7 +2,7 @@ import { formatDate } from './utils.js';
 import { API_BASE_URL } from './config.js';
 export let bets = [];
 
-const API_URL = `${API_BASE_URL}/api/bets`;
+const API_URL = `${API_BASE_URL}/bets`;
 
 function authHeaders(extra = {}) {
   const token = localStorage.getItem('token');

--- a/js/config.js
+++ b/js/config.js
@@ -1,1 +1,1 @@
-export const API_BASE_URL = window.API_BASE_URL || 'http://localhost:5000';
+export const API_BASE_URL = window.API_BASE_URL || 'http://localhost:3000/api';

--- a/js/login.js
+++ b/js/login.js
@@ -6,7 +6,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
   const password = document.getElementById('password').value;
 
   try {
-    const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
+    const res = await fetch(`${API_BASE_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })

--- a/js/register.js
+++ b/js/register.js
@@ -6,7 +6,7 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
   const password = document.getElementById('password').value;
 
   try {
-    const res = await fetch(`${API_BASE_URL}/api/auth/register`, {
+    const res = await fetch(`${API_BASE_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })

--- a/login.html
+++ b/login.html
@@ -26,6 +26,11 @@
       </form>
     </div>
   </div>
+  <!-- Set this to your live backend in production -->
+  <script>
+    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
+  </script>
+
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/login.js"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -71,7 +71,12 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
-  <script src="js/loadShared.js"></script>
-  <script type="module" src="js/app.js"></script>
+    <!-- Set this to your live backend in production -->
+    <script>
+      window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
+    </script>
+
+    <script src="js/loadShared.js"></script>
+    <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -26,6 +26,11 @@
       </form>
     </div>
   </div>
+  <!-- Set this to your live backend in production -->
+  <script>
+    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
+  </script>
+
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/register.js"></script>
 </body>

--- a/settings.html
+++ b/settings.html
@@ -23,9 +23,14 @@
       </div>
     </div>
 
-  <script src="js/loadShared.js"></script>
-  <script type="module" src="js/app.js"></script>
-  <script src="js/auth.js"></script>
+    <!-- Set this to your live backend in production -->
+    <script>
+      window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
+    </script>
+
+    <script src="js/loadShared.js"></script>
+    <script type="module" src="js/app.js"></script>
+    <script src="js/auth.js"></script>
   <script>
     window.addEventListener('shared:loaded', () => {
       const title = document.getElementById('page-title');


### PR DESCRIPTION
## Summary
- set global `window.API_BASE_URL` in all pages for live backend
- refactor fetch calls to rely on `API_BASE_URL`
- default config to localhost:3000/api when global not defined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bbcdaa5c4832381fe914478fc9aec