### PR TITLE
feat: configure backend allowed origins via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Betting Tracker
+
+## Environment Variables
+
+The backend uses an `ALLOWED_ORIGINS` variable to control which origins may
+make cross-origin requests.
+
+```
+ALLOWED_ORIGINS=http://localhost:3000,https://your-vercel-app.vercel.app
+```
+
+Provide a comma-separated list of origins; each origin will be trimmed and
+checked against incoming request origins.

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -8,26 +8,32 @@ const app = express();
 const PORT = process.env.PORT || 5000;
 
 // CORS configuration
-const allowedOrigins = [
-  'http://localhost:3000',  // Local development
-  'http://localhost:5000',  // Local backend
-  'https://your-vercel-app.vercel.app'  // Your Vercel frontend URL
-];
+const allowedOrigins = new Set(
+  (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean)
+);
 
 // Middleware
 app.use(cors({
   origin: function(origin, callback) {
     // Allow requests with no origin (like mobile apps or curl requests)
-    if (!origin) return callback(null, true);
-    
-    if (allowedOrigins.indexOf(origin) === -1) {
-      const msg = 'The CORS policy for this site does not allow access from the specified Origin.';
-      return callback(new Error(msg), false);
+    if (!origin || allowedOrigins.has(origin)) {
+      return callback(null, true);
     }
-    return callback(null, true);
+    return callback(null, false);
   },
   credentials: true
 }));
+
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin && !allowedOrigins.has(origin)) {
+    return res.sendStatus(403);
+  }
+  next();
+});
 
 app.use(express.json());
 


### PR DESCRIPTION
## Summary
- build CORS allowlist from `ALLOWED_ORIGINS` env var
- return 403 for requests from disallowed origins
- document `ALLOWED_ORIGINS` variable

## Testing
- `npm test`
- `npm test --prefix betting-tracker-backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689bd79d45b883239c6c975554678fae