### PR TITLE
Add health check endpoint to backend

### DIFF
--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -37,6 +37,8 @@ app.use((req, res, next) => {
 
 app.use(express.json());
 
+app.get('/api/health', (_, res) => res.json({ status: 'ok' }));
+
 // MongoDB Connection
 mongoose.connect(process.env.MONGO_URI, {
   useNewUrlParser: true,


### PR DESCRIPTION
## Summary
- expose `/api/health` endpoint returning JSON status for quick service checks

## Testing
- `npm test`
- `npm test` (backend, fails: Error: no test specified)
- `curl -i http://localhost:5000/api/health`


------
https://chatgpt.com/codex/tasks/task_e_689bd87864188323a95f8710e641afba