### PR TITLE
chore: remove deprecated mongoose options

### DIFF
--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -40,12 +40,9 @@ app.use(express.json());
 app.get('/api/health', (_, res) => res.json({ status: 'ok' }));
 
 // MongoDB Connection
-mongoose.connect(process.env.MONGO_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true
-})
-.then(() => console.log('✅ MongoDB connected'))
-.catch((err) => console.error('❌ MongoDB connection error:', err));
+mongoose.connect(process.env.MONGO_URI)
+  .then(() => console.log('✅ MongoDB connected'))
+  .catch((err) => console.error('❌ MongoDB connection error:', err));
 
 // Example route
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- drop useNewUrlParser and useUnifiedTopology from mongoose connection to rely on defaults

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` *(no tests)*
- `node server.js` *(fails: querySrv ENOTFOUND _mongodb._tcp.moneylineplayers.wx2jkww.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_689bd934610c8323baababb3ab928874