### PR TITLE
Handle CORS preflight for invalid origins

### DIFF
--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -15,8 +15,7 @@ const allowedOrigins = new Set(
     .filter(Boolean)
 );
 
-// Middleware
-app.use(cors({
+const corsOptions = {
   origin: function(origin, callback) {
     // Allow requests with no origin (like mobile apps or curl requests)
     if (!origin || allowedOrigins.has(origin)) {
@@ -24,16 +23,12 @@ app.use(cors({
     }
     return callback(null, false);
   },
-  credentials: true
-}));
+  credentials: true,
+};
 
-app.use((req, res, next) => {
-  const origin = req.headers.origin;
-  if (origin && !allowedOrigins.has(origin)) {
-    return res.sendStatus(403);
-  }
-  next();
-});
+// Middleware
+app.use(cors(corsOptions));
+app.options('*', cors(corsOptions));
 
 app.use(express.json());
 
@@ -53,6 +48,18 @@ app.get('/', (req, res) => {
 const betRoutes = require('./routes/bets');
 const userRoutes = require('./routes/users');
 app.use('/api/auth', require('./routes/auth'));
+
+app.use((req, res, next) => {
+  const origin = req.headers.origin;
+  if (origin && !allowedOrigins.has(origin)) {
+    if (req.method === 'OPTIONS') {
+      return res.sendStatus(204);
+    }
+    return res.sendStatus(403);
+  }
+  next();
+});
+
 app.use('/api/bets', auth, betRoutes);
 app.use('/api/users', auth, userRoutes);
 


### PR DESCRIPTION
## Summary
- Add explicit CORS options handler to handle preflight requests with same origin logic as main middleware
- Return 204 instead of 500/403 for invalid-origin OPTIONS requests before protected routes

## Testing
- `npm test`
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689bda45d95083238e5992ecc74b8d3f