### PR TITLE
chore: centralize vercel configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "server.js",
+      "src": "api/index.js",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
       "src": "/(.*)",
-      "dest": "/server.js"
+      "dest": "/api/index.js"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- remove backend-specific vercel config
- add root vercel config pointing builds and routes to api/index.js

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf845214083238ef0cb916203b4d6