### PR TITLE
Add centralized error handling middleware

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -103,6 +103,11 @@ if (missingEnv.length) {
     app.use('/auth', authRouter);
     app.use('/bets', auth, betRoutes);
     app.use('/users', auth, userRoutes);
+
+    app.use((err, req, res, next) => {
+      console.error(err);
+      res.status(500).json({ error: 'Internal server error' });
+    });
   } catch (err) {
     console.error('Failed to connect to database', err);
     app.use((_, res) =>

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -5,7 +5,7 @@ import User from '../models/User.js';
 
 const router = Router();
 
-router.post('/register', async (req, res) => {
+router.post('/register', async (req, res, next) => {
   try {
     const { username, password, role } = req.body;
     if (!username || !password) {
@@ -21,11 +21,11 @@ router.post('/register', async (req, res) => {
     const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
     res.status(201).json({ token });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    next(err);
   }
 });
 
-router.post('/login', async (req, res) => {
+router.post('/login', async (req, res, next) => {
   try {
     const { username, password } = req.body;
     const user = await User.findOne({ username });
@@ -39,7 +39,7 @@ router.post('/login', async (req, res) => {
     const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
     res.json({ token });
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    next(err);
   }
 });
 

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -3,38 +3,54 @@ import Bet from '../models/Bet.js';
 
 const router = Router();
 
-router.get('/', async (req, res) => {
-  const bets = await Bet.find();
-  res.json(bets);
+router.get('/', async (req, res, next) => {
+  try {
+    const bets = await Bet.find();
+    res.json(bets);
+  } catch (err) {
+    next(err);
+  }
 });
 
-router.post('/', async (req, res) => {
+router.post('/', async (req, res, next) => {
   try {
     const newBet = new Bet(req.body);
     await newBet.save();
     res.status(201).json(newBet);
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    next(err);
   }
 });
 
-router.delete('/', async (req, res) => {
-  await Bet.deleteMany({});
-  res.json({ message: 'All bets deleted' });
+router.delete('/', async (req, res, next) => {
+  try {
+    await Bet.deleteMany({});
+    res.json({ message: 'All bets deleted' });
+  } catch (err) {
+    next(err);
+  }
 });
 
-router.put('/:id', async (req, res) => {
+router.put('/:id', async (req, res, next) => {
   try {
-    const updatedBet = await Bet.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const updatedBet = await Bet.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true }
+    );
     res.json(updatedBet);
   } catch (err) {
-    res.status(400).json({ error: err.message });
+    next(err);
   }
 });
 
-router.delete('/:id', async (req, res) => {
-  await Bet.findByIdAndDelete(req.params.id);
-  res.json({ message: 'Bet deleted' });
+router.delete('/:id', async (req, res, next) => {
+  try {
+    await Bet.findByIdAndDelete(req.params.id);
+    res.json({ message: 'Bet deleted' });
+  } catch (err) {
+    next(err);
+  }
 });
 
 export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -4,12 +4,12 @@ import authorize from '../middleware/authorize.js';
 
 const router = Router();
 
-router.get('/', authorize('admin'), async (req, res) => {
+router.get('/', authorize('admin'), async (req, res, next) => {
   try {
     const users = await User.find().select('username');
     res.json(users);
   } catch (err) {
-    res.status(500).json({ error: err.message });
+    next(err);
   }
 });
 


### PR DESCRIPTION
## Summary
- add global Express error handler
- forward unexpected route errors to central handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c0252c8988323ae88250f2423c5cf