### PR TITLE
refactor: centralize API base URL

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -12,11 +12,6 @@
     <h2 id="user-count-header">Total Users: 0</h2>
     <ul id="user-list"></ul>
   </div>
-  <!-- Set this to your live backend in production -->
-  <script>
-    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
-  </script>
-
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -120,11 +120,6 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
-  <!-- Set this to your live backend in production -->
-  <script>
-    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
-  </script>
-
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
 </body>

--- a/js/config.js
+++ b/js/config.js
@@ -1,1 +1,3 @@
-export const API_BASE_URL = window.API_BASE_URL || 'http://localhost:3000/api';
+const defaultApiBase = 'https://betting-tracker-backend.vercel.app/api';
+export const API_BASE_URL =
+  (typeof process !== 'undefined' && process.env?.API_BASE_URL) || defaultApiBase;

--- a/login.html
+++ b/login.html
@@ -26,11 +26,6 @@
       </form>
     </div>
   </div>
-  <!-- Set this to your live backend in production -->
-  <script>
-    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
-  </script>
-
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/login.js"></script>
 </body>

--- a/profile.html
+++ b/profile.html
@@ -71,12 +71,7 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
-    <!-- Set this to your live backend in production -->
-    <script>
-      window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
-    </script>
-
-    <script src="js/loadShared.js"></script>
-    <script type="module" src="js/app.js"></script>
+  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -26,11 +26,6 @@
       </form>
     </div>
   </div>
-  <!-- Set this to your live backend in production -->
-  <script>
-    window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
-  </script>
-
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/register.js"></script>
 </body>

--- a/settings.html
+++ b/settings.html
@@ -23,11 +23,6 @@
       </div>
     </div>
 
-    <!-- Set this to your live backend in production -->
-    <script>
-      window.API_BASE_URL = 'https://betting-tracker-backend-r0koq87x5-tokken10s-projects.vercel.app/api';
-    </script>
-
     <script src="js/loadShared.js"></script>
     <script type="module" src="js/app.js"></script>
     <script src="js/auth.js"></script>


### PR DESCRIPTION
## Summary
- centralize API base URL with env variable and default to hosted backend
- remove hard-coded backend URL script tags from static HTML pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc13f6a5c8323834183bce17f743b