### PR TITLE
feat: support comma-separated CORS origins

### DIFF
--- a/betting-tracker-backend/README.md
+++ b/betting-tracker-backend/README.md
@@ -15,13 +15,11 @@ In your Vercel project settings add:
 ```
 FRONTEND_URL=https://betting-tracker-nine.vercel.app
 FRONTEND_URL_ALT=https://your-custom-domain.com  # optional
+ALLOWED_ORIGINS=https://example1.com,https://example2.com  # optional, comma-separated
 ```
 
-You can also manage origins entirely through the `ALLOWED_ORIGINS` variable. Provide comma‑separated values and prefix any regular expression with `re:`:
-
-```
-ALLOWED_ORIGINS=https://betting-tracker-nine.vercel.app,http://localhost:3000,re:^https?:\/\/betting-tracker-nine(-[a-z0-9-]+)?\.vercel\.app$
-```
+`ALLOWED_ORIGINS` is parsed as a comma-separated list and merged with the
+exact origins above.
 
 ### Frontend API calls
 

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -8,7 +8,13 @@ const app = express();
 const PORT = process.env.PORT || 5000;
 
 // CORS configuration
+const envOrigins = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
 const exactOrigins = [
+  ...envOrigins,
   process.env.FRONTEND_URL,       // e.g. https://betting-tracker-nine.vercel.app
   process.env.FRONTEND_URL_ALT,   // e.g. https://your-custom-domain.com
   'http://localhost:3000',


### PR DESCRIPTION
## Summary
- parse `ALLOWED_ORIGINS` env variable and merge into CORS allowlist
- document `ALLOWED_ORIGINS` usage

## Testing
- `npm test` (betting-tracker-backend, fails: no test specified)
- `npm test` (root, no tests)


------
https://chatgpt.com/codex/tasks/task_e_689cc416455c8323b5f656c877a4d12b