### PR TITLE
Add JWT expiration and handle token expiry

### DIFF
--- a/betting-tracker-backend/middleware/auth.js
+++ b/betting-tracker-backend/middleware/auth.js
@@ -11,6 +11,9 @@ module.exports = function (req, res, next) {
     req.user = decoded;
     next();
   } catch (err) {
+    if (err.name === 'TokenExpiredError') {
+      return res.status(401).json({ error: 'Token expired' });
+    }
     res.status(403).json({ error: 'Invalid token' });
   }
 };

--- a/betting-tracker-backend/routes/auth.js
+++ b/betting-tracker-backend/routes/auth.js
@@ -18,7 +18,11 @@ router.post('/register', async (req, res) => {
     const hashedPassword = await bcrypt.hash(password, 10);
     user = new User({ username, password: hashedPassword, role: role || 'user' });
     await user.save();
-    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
+    const token = jwt.sign(
+      { id: user._id, username: user.username, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
     res.status(201).json({ token });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -36,7 +40,11 @@ router.post('/login', async (req, res) => {
     if (!isMatch) {
       return res.status(400).json({ error: 'Invalid credentials' });
     }
-    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET);
+    const token = jwt.sign(
+      { id: user._id, username: user.username, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
     res.json({ token });
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- add 7-day expiration to JWT tokens on registration and login
- return a clear 401 error when JWTs are expired

## Testing
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689cc5349a9083238be173029b01f22f