### PR TITLE
Associate bets with authenticated users

### DIFF
--- a/betting-tracker-backend/models/Bet.js
+++ b/betting-tracker-backend/models/Bet.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 
 const BetSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   date: String,
   sport: String,
   event: String,

--- a/betting-tracker-backend/routes/bets.js
+++ b/betting-tracker-backend/routes/bets.js
@@ -1,17 +1,18 @@
 const express = require('express');
 const router = express.Router();
 const Bet = require('../models/Bet');
+const authorize = require('../middleware/authorize');
 
-// Get all bets
+// Get all bets for the authenticated user
 router.get('/', async (req, res) => {
-  const bets = await Bet.find();
+  const bets = await Bet.find({ user: req.user.id });
   res.json(bets);
 });
 
-// Add a new bet
+// Add a new bet for the authenticated user
 router.post('/', async (req, res) => {
   try {
-    const newBet = new Bet(req.body);
+    const newBet = new Bet({ ...req.body, user: req.user.id });
     await newBet.save();
     res.status(201).json(newBet);
   } catch (err) {
@@ -19,27 +20,29 @@ router.post('/', async (req, res) => {
   }
 });
 
-// Delete all bets
-router.delete('/', async (req, res) => {
-  await Bet.deleteMany({});
+// Delete all bets for the authenticated user (admin only)
+router.delete('/', authorize('admin'), async (req, res) => {
+  await Bet.deleteMany({ user: req.user.id });
   res.json({ message: 'All bets deleted' });
 });
 
-// Update a bet
+// Update a bet for the authenticated user
 router.put('/:id', async (req, res) => {
   try {
-    const updatedBet = await Bet.findByIdAndUpdate(req.params.id, req.body, {
-      new: true,
-    });
+    const updatedBet = await Bet.findOneAndUpdate(
+      { _id: req.params.id, user: req.user.id },
+      req.body,
+      { new: true }
+    );
     res.json(updatedBet);
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
 });
 
-// Delete a bet
+// Delete a bet for the authenticated user
 router.delete('/:id', async (req, res) => {
-  await Bet.findByIdAndDelete(req.params.id);
+  await Bet.findOneAndDelete({ _id: req.params.id, user: req.user.id });
   res.json({ message: 'Bet deleted' });
 });
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vercel dev",
     "start": "node api/index.js",
-    "test": "echo \"No tests\""
+    "test": "echo \"No tests\"",
+    "migrate:bet-users": "node scripts/assignUserToBets.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",

--- a/scripts/assignUserToBets.js
+++ b/scripts/assignUserToBets.js
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+import connectDB from '../src/db.js';
+import Bet from '../src/models/Bet.js';
+
+const userId = process.argv[2] || process.env.USER_ID;
+if (!userId) {
+  console.error('Usage: node scripts/assignUserToBets.js <userId>');
+  process.exit(1);
+}
+
+(async () => {
+  try {
+    await connectDB();
+    const result = await Bet.updateMany(
+      { user: { $exists: false } },
+      { $set: { user: userId } }
+    );
+    console.log(`Updated ${result.modifiedCount} bets`);
+  } catch (err) {
+    console.error(err);
+  } finally {
+    await mongoose.disconnect();
+  }
+})();

--- a/src/models/Bet.js
+++ b/src/models/Bet.js
@@ -1,6 +1,7 @@
 import mongoose from 'mongoose';
 
 const BetSchema = new mongoose.Schema({
+  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   date: String,
   sport: String,
   event: String,

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -19,7 +19,7 @@ function validateBet(data) {
 
 router.get('/', async (req, res) => {
   try {
-    const bets = await Bet.find();
+    const bets = await Bet.find({ user: req.user.id });
     res.json(bets);
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch bets' });
@@ -33,7 +33,7 @@ router.post('/', async (req, res) => {
     return res.status(400).json({ error: validationError });
   }
   try {
-    const newBet = new Bet(req.body);
+    const newBet = new Bet({ ...req.body, user: req.user.id });
     await newBet.save();
     res.status(201).json(newBet);
   } catch (err) {
@@ -47,7 +47,7 @@ router.delete('/', authorize('admin'), async (req, res) => {
     if (req.user.role !== 'admin') {
       return res.status(403).json({ error: 'Access denied' });
     }
-    await Bet.deleteMany({});
+    await Bet.deleteMany({ user: req.user.id });
     res.json({ message: 'All bets deleted' });
   } catch (err) {
     res.status(500).json({ error: 'Failed to delete bets' });
@@ -61,7 +61,11 @@ router.put('/:id', async (req, res) => {
     return res.status(400).json({ error: validationError });
   }
   try {
-    const updatedBet = await Bet.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    const updatedBet = await Bet.findOneAndUpdate(
+      { _id: req.params.id, user: req.user.id },
+      req.body,
+      { new: true }
+    );
     res.json(updatedBet);
   } catch (err) {
     console.error(err);
@@ -70,7 +74,7 @@ router.put('/:id', async (req, res) => {
 });
 
 router.delete('/:id', async (req, res) => {
-  await Bet.findByIdAndDelete(req.params.id);
+  await Bet.findOneAndDelete({ _id: req.params.id, user: req.user.id });
   res.json({ message: 'Bet deleted' });
 });
 


### PR DESCRIPTION
## Summary
- Add `user` reference to `Bet` schema and align routes to create and query bets per user
- Backfill script to associate existing bets with a user
- Mirror changes in legacy backend for parity

## Testing
- `npm test`
- `cd betting-tracker-backend && npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689cca67670c8323901141913ece07e5