### PR TITLE
Add dotenv support for scripts and document environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Betting Tracker
+
+## Environment Setup
+
+Create a `.env` file in the project root to configure environment variables used by the application and scripts.
+
+```env
+# MongoDB connection string
+MONGO_URI=mongodb+srv://user:password@cluster.mongodb.net/dbname
+
+# Secret used for signing JSON Web Tokens
+JWT_SECRET=replace_this_with_a_secure_value
+
+# Comma separated list of origins allowed to access the API
+ALLOWED_ORIGINS=http://localhost:3000
+
+# Optional: default user ID for scripts/assignUserToBets.js
+# USER_ID=<mongo_user_id>
+```
+
+The scripts in the `scripts/` directory load these values via [`dotenv`](https://www.npmjs.com/package/dotenv). Ensure the `.env` file exists before running commands such as:
+
+```bash
+npm run seed:nowbenj
+npm run migrate:bet-users
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "bcrypt": "^5.1.1",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
+        "dotenv": "^17.2.1",
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.6.0"
@@ -766,6 +767,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/create-require": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bcrypt": "^5.1.1",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.1",
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.6.0"

--- a/scripts/assignUserToBets.js
+++ b/scripts/assignUserToBets.js
@@ -1,3 +1,6 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
 import mongoose from 'mongoose';
 import connectDB from '../src/db.js';
 import Bet from '../src/models/Bet.js';

--- a/scripts/seedNowbenj.js
+++ b/scripts/seedNowbenj.js
@@ -1,3 +1,6 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
 import mongoose from 'mongoose';
 import bcrypt from 'bcrypt';
 import connectDB from '../src/db.js';


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv` in database utility scripts so `MONGO_URI` is available
- document required `.env` variables including `MONGO_URI`, `JWT_SECRET`, and `ALLOWED_ORIGINS`
- add `dotenv` dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d7cf5e41083239c6e3a9829450154