### PR TITLE
Restrict clearing all bets to admins

### DIFF
--- a/betting-tracker-backend/routes/bets.js
+++ b/betting-tracker-backend/routes/bets.js
@@ -20,9 +20,9 @@ router.post('/', async (req, res) => {
   }
 });
 
-// Delete all bets for the authenticated user (admin only)
+// Delete all bets from the database (admin only)
 router.delete('/', authorize('admin'), async (req, res) => {
-  await Bet.deleteMany({ user: req.user.id });
+  await Bet.deleteMany({});
   res.json({ message: 'All bets deleted' });
 });
 

--- a/js/form.js
+++ b/js/form.js
@@ -1,6 +1,7 @@
 import { addBet as addBetData, clearBets, calculatePayout } from './bets.js';
 import { renderBets } from './render.js';
 import { updateStats } from './stats.js';
+import { decodeToken } from './utils.js';
 
 export function initForm() {
   const outcomeEl = document.getElementById('outcome');
@@ -88,6 +89,12 @@ export async function handleAddBet() {
 }
 
 export async function handleClearAll() {
+  const token = localStorage.getItem('token');
+  const user = token ? decodeToken(token) : null;
+  if (!user || user.role !== 'admin') {
+    alert('Only admins can clear all bets.');
+    return;
+  }
   if (confirm('Are you sure you want to clear all betting data? This cannot be undone.')) {
     await clearBets();
     renderBets();

--- a/settings.html
+++ b/settings.html
@@ -26,7 +26,9 @@
     <script src="js/loadShared.js"></script>
     <script type="module" src="js/app.js"></script>
     <script src="js/auth.js"></script>
-  <script>
+  <script type="module">
+    import { decodeToken } from './js/utils.js';
+
     window.addEventListener('shared:loaded', () => {
       const title = document.getElementById('page-title');
       const subtitle = document.getElementById('page-subtitle');
@@ -34,6 +36,13 @@
       if (title) title.textContent = '⚙️ Settings';
       if (subtitle) subtitle.textContent = 'Manage application settings';
       if (learnMore) learnMore.style.display = 'none';
+
+      const token = localStorage.getItem('token');
+      const user = token ? decodeToken(token) : null;
+      if (!user || user.role !== 'admin') {
+        const clearBtn = document.querySelector('button[onclick="clearAllBets()"]');
+        if (clearBtn) clearBtn.style.display = 'none';
+      }
     });
   </script>
 </body>

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -44,10 +44,7 @@ router.post('/', async (req, res) => {
 
 router.delete('/', authorize('admin'), async (req, res) => {
   try {
-    if (req.user.role !== 'admin') {
-      return res.status(403).json({ error: 'Access denied' });
-    }
-    await Bet.deleteMany({ user: req.user.id });
+    await Bet.deleteMany({});
     res.json({ message: 'All bets deleted' });
   } catch (err) {
     res.status(500).json({ error: 'Failed to delete bets' });


### PR DESCRIPTION
## Summary
- Allow only admins to clear the entire bets collection
- Guard frontend clear-all action behind admin check
- Hide clear-all button for non-admin users in settings page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d85a6b3f88323b3c11d6c4f3b5e7f