### PR TITLE
Restrict clearing all bets to admins

### DIFF
--- a/js/bets.js
+++ b/js/bets.js
@@ -69,11 +69,13 @@ export async function removeBet(betId) {
 
 /** Clear all bets */
 export async function clearBets() {
-  bets = [];
   try {
-    await fetch(API_URL, { method: 'DELETE', headers: authHeaders() });
+    const res = await fetch(API_URL, { method: 'DELETE', headers: authHeaders() });
+    if (!res.ok) throw new Error('Failed to clear bets');
+    bets = [];
   } catch (err) {
     console.error('❌ Error clearing bets:', err.message);
+    throw err;
   }
 }
 

--- a/js/form.js
+++ b/js/form.js
@@ -1,6 +1,7 @@
 import { addBet as addBetData, clearBets, calculatePayout } from './bets.js';
 import { renderBets } from './render.js';
 import { updateStats } from './stats.js';
+import { decodeToken } from './utils.js';
 
 export function initForm() {
   const outcomeEl = document.getElementById('outcome');
@@ -88,10 +89,20 @@ export async function handleAddBet() {
 }
 
 export async function handleClearAll() {
+  const token = localStorage.getItem('token');
+  const user = token ? decodeToken(token) : null;
+  if (!user || user.role !== 'admin') {
+    alert('Only admins can clear all bets.');
+    return;
+  }
   if (confirm('Are you sure you want to clear all betting data? This cannot be undone.')) {
-    await clearBets();
-    renderBets();
-    updateStats();
+    try {
+      await clearBets();
+      renderBets();
+      updateStats();
+    } catch (err) {
+      alert('Failed to clear bets.');
+    }
   }
 }
 

--- a/settings.html
+++ b/settings.html
@@ -26,7 +26,9 @@
     <script src="js/loadShared.js"></script>
     <script type="module" src="js/app.js"></script>
     <script src="js/auth.js"></script>
-  <script>
+  <script type="module">
+    import { decodeToken } from './js/utils.js';
+
     window.addEventListener('shared:loaded', () => {
       const title = document.getElementById('page-title');
       const subtitle = document.getElementById('page-subtitle');
@@ -34,6 +36,13 @@
       if (title) title.textContent = '⚙️ Settings';
       if (subtitle) subtitle.textContent = 'Manage application settings';
       if (learnMore) learnMore.style.display = 'none';
+
+      const token = localStorage.getItem('token');
+      const user = token ? decodeToken(token) : null;
+      if (!user || user.role !== 'admin') {
+        const clearBtn = document.querySelector('button[onclick="clearAllBets()"]');
+        if (clearBtn) clearBtn.style.display = 'none';
+      }
     });
   </script>
 </body>

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -19,7 +19,8 @@ function validateBet(data) {
 
 router.get('/', async (req, res) => {
   try {
-    const bets = await Bet.find({ user: req.user.id });
+    const filter = req.user.role === 'admin' ? {} : { user: req.user.id };
+    const bets = await Bet.find(filter);
     res.json(bets);
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch bets' });
@@ -44,10 +45,7 @@ router.post('/', async (req, res) => {
 
 router.delete('/', authorize('admin'), async (req, res) => {
   try {
-    if (req.user.role !== 'admin') {
-      return res.status(403).json({ error: 'Access denied' });
-    }
-    await Bet.deleteMany({ user: req.user.id });
+    await Bet.deleteMany({});
     res.json({ message: 'All bets deleted' });
   } catch (err) {
     res.status(500).json({ error: 'Failed to delete bets' });
@@ -61,11 +59,10 @@ router.put('/:id', async (req, res) => {
     return res.status(400).json({ error: validationError });
   }
   try {
-    const updatedBet = await Bet.findOneAndUpdate(
-      { _id: req.params.id, user: req.user.id },
-      req.body,
-      { new: true }
-    );
+    const filter = req.user.role === 'admin'
+      ? { _id: req.params.id }
+      : { _id: req.params.id, user: req.user.id };
+    const updatedBet = await Bet.findOneAndUpdate(filter, req.body, { new: true });
     res.json(updatedBet);
   } catch (err) {
     console.error(err);
@@ -74,7 +71,10 @@ router.put('/:id', async (req, res) => {
 });
 
 router.delete('/:id', async (req, res) => {
-  await Bet.findOneAndDelete({ _id: req.params.id, user: req.user.id });
+  const filter = req.user.role === 'admin'
+    ? { _id: req.params.id }
+    : { _id: req.params.id, user: req.user.id };
+  await Bet.findOneAndDelete(filter);
   res.json({ message: 'Bet deleted' });
 });
 


### PR DESCRIPTION
## Summary
- Show admins all bets and let them update or delete any user's bet
- Ensure admin-only endpoint truly clears the entire bets collection
- Only clear client state after server deletion succeeds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d85a6b3f88323b3c11d6c4f3b5e7f