### PR TITLE
Improve navigation design with responsive menu and compact profile header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,21 +28,36 @@ body {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 10px;
+    position: relative;
+  }
+
+  .header .nav-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: white;
+    font-size: 24px;
+    cursor: pointer;
   }
 
   .header .nav-links {
     display: flex;
-    gap: 15px;
+    gap: 20px;
   }
 
   .header .nav-links a {
     color: white;
     text-decoration: none;
     font-size: 14px;
+    padding: 6px 12px;
+    border-radius: 4px;
+    background: rgba(255,255,255,0.1);
+    transition: background 0.3s;
   }
 
   .header .nav-links a:hover {
-    text-decoration: underline;
+    background: rgba(255,255,255,0.25);
+    text-decoration: none;
   }
 
   .header .top-nav .user-display {
@@ -63,7 +78,7 @@ body {
   font-size: 24px;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 600px) {
   .header {
     padding-top: 20px;
   }
@@ -72,14 +87,30 @@ body {
     font-size: 20px;
   }
 
-  .header .top-nav {
-    flex-direction: column;
-    gap: 8px;
+  .header .nav-toggle {
+    display: block;
   }
 
   .header .nav-links {
-    flex-wrap: wrap;
-    justify-content: center;
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    flex-direction: column;
+    background: #2c3e50;
+    width: 100%;
+    gap: 0;
+  }
+
+  .header .nav-links a {
+    padding: 12px 20px;
+    border-radius: 0;
+    background: transparent;
+    border-top: 1px solid rgba(255,255,255,0.1);
+  }
+
+  .header .nav-links.open {
+    display: flex;
   }
 }
 

--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -47,6 +47,14 @@ async function loadSharedComponents() {
         if (adminLink && user?.role !== 'admin') {
           adminLink.style.display = 'none';
         }
+
+        const navToggle = target.querySelector('.nav-toggle');
+        const navLinks = target.querySelector('.nav-links');
+        if (navToggle && navLinks) {
+          navToggle.addEventListener('click', () => {
+            navLinks.classList.toggle('open');
+          });
+        }
       }
 
       // Profile-specific behavior

--- a/profile.html
+++ b/profile.html
@@ -6,18 +6,26 @@
   <title>Betting Profile</title>
   <link rel="stylesheet" href="css/style.css" />
   <style>
+    /* Compact header adjustments for profile page */
+    .profile-page .header {
+      padding: 10px;
+    }
+
+    .profile-page .header .top-nav {
+      margin-bottom: 5px;
+    }
+
     .profile-avatar {
-      width: 60px;
-      height: 60px;
+      width: 40px;
+      height: 40px;
       background: #2980b9;
       color: white;
       font-weight: bold;
-      font-size: 24px;
+      font-size: 18px;
       border-radius: 50%;
       display: flex;
       align-items: center;
       justify-content: center;
-      margin-right: 15px;
     }
 
     .profile-header-container {
@@ -25,17 +33,27 @@
       align-items: center;
       justify-content: center;
       flex-wrap: wrap;
-      gap: 16px;
-      padding: 20px;
-      flex-direction: column;
+      gap: 10px;
+      padding: 10px;
+      flex-direction: row;
       text-align: center;
       color: white;
     }
 
+    .profile-header-container h1 {
+      font-size: 18px;
+      margin: 0;
+    }
+
+    .profile-header-container p {
+      margin: 0;
+      font-size: 12px;
+    }
+
     .profile-header-insights {
-      font-size: 14px;
+      font-size: 12px;
       color: white;
-      margin-top: 10px;
+      margin-top: 4px;
     }
 
     .highlight {
@@ -50,10 +68,9 @@
     .negative {
       color: #e74c3c;
     }
-
   </style>
 </head>
-<body>
+<body class="profile-page">
   <div class="container">
     <!-- HEADER -->
     <div id="include-header"></div>

--- a/shared/header.html
+++ b/shared/header.html
@@ -1,5 +1,6 @@
 <div class="header">
   <nav class="top-nav">
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
     <div class="nav-links">
       <a href="index.html">Tracker</a>
       <a href="profile.html">Profile</a>


### PR DESCRIPTION
## Summary
- Add hamburger menu toggle and style nav links for better visual separation
- Implement responsive CSS to collapse nav links into dropdown on small screens
- Wire up nav toggle interaction in shared component loader
- Halve profile page header height with smaller avatar and horizontally aligned details

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e11b0f6fc8323b4f0a10e554dc164