### PR TITLE
feat: improve header layout and profile stats

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,7 +25,7 @@ body {
 
   .header .top-nav {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     margin-bottom: 10px;
     position: relative;
@@ -33,6 +33,10 @@ body {
 
   .header .nav-toggle {
     display: none;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
     background: none;
     border: none;
     color: white;
@@ -58,11 +62,6 @@ body {
   .header .nav-links a:hover {
     background: rgba(255,255,255,0.25);
     text-decoration: none;
-  }
-
-  .header .top-nav .user-display {
-    color: white;
-    font-size: 14px;
   }
 
  .header .learn-more-link {
@@ -120,7 +119,7 @@ body {
   color: white;
   padding: 15px;
   gap: 30px;
-  font-size: 14px;
+  font-size: 16px;
   flex-wrap: wrap;
 }
 
@@ -131,18 +130,18 @@ body {
 }
 
 .stat-value {
-  font-size: 18px;
+  font-size: 22px;
   font-weight: bold;
   margin-bottom: 5px;
 }
 
 @media (max-width: 600px) {
   .stats-bar {
-    font-size: 12px;
+    font-size: 14px;
   }
 
   .stat-value {
-    font-size: 14px;
+    font-size: 18px;
   }
 }
 

--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -10,8 +10,6 @@ function getUser() {
 
 function applyUsername(container, username) {
   if (!username) return;
-  const userDisplay = container.querySelector('#current-user');
-  if (userDisplay) userDisplay.textContent = username;
 
   const profileName = container.querySelector('#profile-username');
   if (profileName) profileName.textContent = username;

--- a/shared/header.html
+++ b/shared/header.html
@@ -1,13 +1,12 @@
 <div class="header">
   <nav class="top-nav">
-    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
     <div class="nav-links">
       <a href="index.html">Tracker</a>
       <a href="profile.html">Profile</a>
       <a href="settings.html">Settings</a>
       <a href="admin.html">Admin</a>
     </div>
-    <span id="current-user" class="user-display"></span>
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
   </nav>
   <h1 id="page-title">🎯 Performance Tracker</h1>
   <p id="page-subtitle">Track your bets meticulously for better bankroll management</p>


### PR DESCRIPTION
## Summary
- Remove username display from shared header and position hamburger menu on the right
- Enlarge text in the profile stats box for better readability
- Clean up username handling in shared JS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e389d25a8832383d104327e855f4a