### PR TITLE
Right-align navigation and enlarge mobile stats text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,7 +25,6 @@ body {
 
   .header .top-nav {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     margin-bottom: 10px;
     position: relative;
@@ -38,11 +37,13 @@ body {
     color: white;
     font-size: 24px;
     cursor: pointer;
+    margin-left: auto;
   }
 
   .header .nav-links {
     display: flex;
     gap: 20px;
+    margin-left: auto;
   }
 
   .header .nav-links a {
@@ -138,11 +139,11 @@ body {
 
 @media (max-width: 600px) {
   .stats-bar {
-    font-size: 12px;
+    font-size: 14px;
   }
 
   .stat-value {
-    font-size: 14px;
+    font-size: 18px;
   }
 }
 

--- a/shared/header.html
+++ b/shared/header.html
@@ -1,13 +1,13 @@
 <div class="header">
   <nav class="top-nav">
-    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
+    <span id="current-user" class="user-display"></span>
     <div class="nav-links">
       <a href="index.html">Tracker</a>
       <a href="profile.html">Profile</a>
       <a href="settings.html">Settings</a>
       <a href="admin.html">Admin</a>
     </div>
-    <span id="current-user" class="user-display"></span>
+    <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
   </nav>
   <h1 id="page-title">🎯 Performance Tracker</h1>
   <p id="page-subtitle">Track your bets meticulously for better bankroll management</p>


### PR DESCRIPTION
## Summary
- Move hamburger toggle to the right and align navigation links to the right on wide screens
- Enlarge stats bar font sizes for mobile devices for improved readability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e42d3405c8323b1a73a4ae1becf72