### PR TITLE
Handle push outcomes and enhance navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -54,11 +54,25 @@ body {
     border-radius: 4px;
     background: rgba(255,255,255,0.1);
     transition: background 0.3s;
+    display: flex;
+    align-items: center;
+    gap: 6px;
   }
 
   .header .nav-links a:hover {
     background: rgba(255,255,255,0.25);
     text-decoration: none;
+  }
+
+  .header .nav-icon-links {
+    display: none;
+    gap: 10px;
+  }
+
+  .header .nav-icon-links a {
+    color: white;
+    text-decoration: none;
+    font-size: 20px;
   }
 
  .header .learn-more-link {
@@ -107,6 +121,11 @@ body {
 
   .header .nav-links.open {
     display: flex;
+  }
+
+  .header .nav-icon-links {
+    display: flex;
+    align-items: center;
   }
 }
 
@@ -253,6 +272,11 @@ tr:hover {
 .pending {
   background-color: #fff3cd !important;
   color: #856404;
+}
+
+.push {
+  background-color: #e2e3e5 !important;
+  color: #383d41;
 }
 
 .positive {

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
             <option value="Over/Under">Over/Under</option>
             <option value="Prop Bet">Prop Bet</option>
             <option value="Parlay">Parlay</option>
+            <option value="Future">Future</option>
             <option value="Other">Other</option>
           </select>
         </div>
@@ -78,6 +79,7 @@
             <option value="">Select Outcome</option>
             <option value="Win">Win</option>
             <option value="Loss">Loss</option>
+            <option value="Push">Push</option>
             <option value="Pending">Pending</option>
           </select>
         </div>

--- a/js/bets.js
+++ b/js/bets.js
@@ -90,6 +90,9 @@ export async function settleBet(betId, newOutcome) {
   } else if (newOutcome === 'Loss') {
     bet.payout = 0;
     bet.profitLoss = -bet.stake;
+  } else if (newOutcome === 'Push') {
+    bet.payout = bet.stake;
+    bet.profitLoss = 0;
   }
 
   try {
@@ -111,21 +114,21 @@ export async function settleBet(betId, newOutcome) {
 
 /** Export all bets to CSV */
 export function exportToCSV() {
-  const headers = ['Date', 'Sport', 'Event', 'Bet Type', 'Odds', 'Stake', 'Outcome', 'Payout', 'Profit/Loss', 'Description', 'Note'];
+  const headers = ['Outcome', 'Description', 'Bet Type', 'Odds', 'Stake', 'Payout', 'Profit/Loss', 'Date', 'Event', 'Sport', 'Note'];
 
   const csvContent = [
     headers.join(','),
     ...bets.map(bet => [
-      formatDate(bet.date),
-      bet.sport,
-      bet.event,
+      bet.outcome,
+      `"${bet.description || ''}"`,
       bet.betType,
       bet.odds,
       parseFloat(bet.stake).toFixed(2),
-      bet.outcome,
       parseFloat(bet.payout).toFixed(2),
       bet.outcome === 'Pending' ? '' : parseFloat(bet.profitLoss).toFixed(2),
-      `"${bet.description || ''}"`,
+      formatDate(bet.date),
+      `"${bet.event}"`,
+      bet.sport,
       `"${bet.note || ''}"`
     ].join(','))
   ].join('\n');

--- a/js/form.js
+++ b/js/form.js
@@ -26,6 +26,8 @@ export function updatePayoutPreview() {
     payoutInput.value = calculatePayout(oddsValue, stake).toFixed(2);
   } else if (outcome === 'Loss') {
     payoutInput.value = '0.00';
+  } else if (outcome === 'Push' && !isNaN(stake)) {
+    payoutInput.value = stake.toFixed(2);
   } else {
     payoutInput.value = '';
   }
@@ -60,6 +62,9 @@ export async function handleAddBet() {
   } else if (outcome === 'Loss') {
     payout = 0;
     profitLoss = -stake;
+  } else if (outcome === 'Push') {
+    payout = stake;
+    profitLoss = 0;
   }
 
   const bet = {

--- a/js/render.js
+++ b/js/render.js
@@ -52,26 +52,26 @@ export function renderBets() {
     const profitSymbol = bet.profitLoss > 0 ? '+' : '';
 
     row.innerHTML = `
-      <td>${formatDate(bet.date)}</td>
-      <td>${bet.sport}</td>
-      <td class="event-cell">
-        <div class="event-content" title="${bet.event}" onclick="showFullText(${JSON.stringify(bet.event)})">
-          ${bet.event}
-        </div>
-      </td>
-      <td>${bet.betType}</td>
+      <td>${bet.outcome}</td>
       <td class="description-cell">
         <div class="description-content" title="${bet.description || ''}" onclick="showFullText(${JSON.stringify(bet.description || '')})">
           ${bet.description || ''}
         </div>
       </td>
+      <td>${bet.betType}</td>
       <td>${bet.odds}</td>
       <td>$${parseFloat(bet.stake).toFixed(2)}</td>
-      <td>${bet.outcome}</td>
       <td>$${parseFloat(bet.payout).toFixed(2)}</td>
       <td class="${profitClass}">
         ${bet.outcome === 'Pending' ? '—' : profitSymbol + '$' + parseFloat(bet.profitLoss).toFixed(2)}
       </td>
+      <td>${formatDate(bet.date)}</td>
+      <td class="event-cell">
+        <div class="event-content" title="${bet.event}" onclick="showFullText(${JSON.stringify(bet.event)})">
+          ${bet.event}
+        </div>
+      </td>
+      <td>${bet.sport}</td>
       <td class="note-cell">
         <div class="note-content" title="${bet.note || ''}" onclick="showFullText(${JSON.stringify(bet.note || '')})">
           ${bet.note || ''}
@@ -85,6 +85,7 @@ export function renderBets() {
                 <option value="">Settle</option>
                 <option value="Win">Win</option>
                 <option value="Loss">Loss</option>
+                <option value="Push">Push</option>
               </select>
               <button class="btn btn-danger" onclick="removeBet('${bet._id}')">Remove</button>
             `

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,8 +1,9 @@
 import { bets } from './bets.js';
 
 export function updateStats() {
-  const settled = bets.filter(b => b.outcome === 'Win' || b.outcome === 'Loss');
-  const wins = settled.filter(b => b.outcome === 'Win').length;
+  const settled = bets.filter(b => ['Win', 'Loss', 'Push'].includes(b.outcome));
+  const decided = bets.filter(b => b.outcome === 'Win' || b.outcome === 'Loss');
+  const wins = decided.filter(b => b.outcome === 'Win').length;
   const totalStaked = settled.reduce((sum, b) => sum + b.stake, 0);
   const totalReturn = settled.reduce((sum, b) => sum + b.payout, 0);
   const netProfit = totalReturn - totalStaked;
@@ -12,7 +13,7 @@ export function updateStats() {
   const el = id => document.getElementById(id);
 
   if (el('totalBets')) el('totalBets').textContent = bets.length;
-  if (el('winRate')) el('winRate').textContent = settled.length ? ((wins / settled.length) * 100).toFixed(1) + '%' : '0%';
+  if (el('winRate')) el('winRate').textContent = decided.length ? ((wins / decided.length) * 100).toFixed(1) + '%' : '0%';
   if (el('totalStaked')) el('totalStaked').textContent = '$' + totalStaked.toFixed(2);
   if (el('totalReturn')) el('totalReturn').textContent = '$' + totalReturn.toFixed(2);
 
@@ -41,9 +42,10 @@ export function updateStats() {
     if (b.outcome === 'Win') {
       streak++;
       if (streak > maxStreak) maxStreak = streak;
-    } else {
+    } else if (b.outcome === 'Loss') {
       streak = 0;
     }
+    // Push leaves streak unchanged
   }
   if (el('winStreak')) el('winStreak').textContent = maxStreak;
   if (el('avgStake')) el('avgStake').textContent = '$' + avgStake;

--- a/shared/header.html
+++ b/shared/header.html
@@ -1,11 +1,15 @@
 <div class="header">
   <nav class="top-nav">
+    <div class="nav-icon-links">
+      <a href="index.html" aria-label="Tracker">📊</a>
+      <a href="profile.html" aria-label="Profile">👤</a>
+    </div>
 
     <div class="nav-links">
-      <a href="index.html">Tracker</a>
-      <a href="profile.html">Profile</a>
-      <a href="settings.html">Settings</a>
-      <a href="admin.html">Admin</a>
+      <a href="index.html">📊 Tracker</a>
+      <a href="profile.html">👤 Profile</a>
+      <a href="settings.html">⚙️ Settings</a>
+      <a href="admin.html">🛠️ Admin</a>
     </div>
     <button class="nav-toggle" aria-label="Toggle navigation">☰</button>
   </nav>

--- a/shared/table.html
+++ b/shared/table.html
@@ -2,16 +2,16 @@
   <table>
     <thead>
       <tr>
-        <th>Date</th>
-        <th>Sport</th>
-        <th>Event</th>
-        <th>Bet Type</th>
+        <th>Outcome</th>
         <th>Description</th>
+        <th>Bet Type</th>
         <th>Odds</th>
         <th>Stake</th>
-        <th>Outcome</th>
         <th>Payout</th>
         <th>Profit/Loss</th>
+        <th>Date</th>
+        <th>Event</th>
+        <th>Sport</th>
         <th>Note</th>
         <th>Action</th>
       </tr>


### PR DESCRIPTION
## Summary
- Reorder bet table columns and CSV export to begin with outcome and description
- Support push results with correct payout, profit/loss, and updated statistics
- Add icons and responsive layout tweaks so tracker/profile icons appear with the hamburger menu
- Include "Future" in bet types

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f6358dc54832394e7035895a17a05