### PR TITLE
Align mobile nav icons with hamburger

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -97,8 +97,15 @@ body {
     font-size: 20px;
   }
 
+  .header .top-nav {
+    justify-content: flex-end;
+  }
+
   .header .nav-toggle {
     display: block;
+    margin-left: 10px;
+    order: 2;
+    font-size: 24px;
   }
 
   .header .nav-links {
@@ -126,6 +133,12 @@ body {
   .header .nav-icon-links {
     display: flex;
     align-items: center;
+    order: 1;
+    gap: 10px;
+  }
+
+  .header .nav-icon-links a {
+    font-size: 24px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Align tracker and profile icons to the right and place them next to the hamburger menu on small screens
- Standardize icon sizes for a consistent mobile navigation bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7307ed94832389578738cae4abbc