### PR TITLE
Reorder event column in betting table

### DIFF
--- a/js/bets.js
+++ b/js/bets.js
@@ -114,12 +114,13 @@ export async function settleBet(betId, newOutcome) {
 
 /** Export all bets to CSV */
 export function exportToCSV() {
-  const headers = ['Outcome', 'Description', 'Bet Type', 'Odds', 'Stake', 'Payout', 'Profit/Loss', 'Date', 'Event', 'Sport', 'Note'];
+  const headers = ['Outcome', 'Event', 'Description', 'Bet Type', 'Odds', 'Stake', 'Payout', 'Profit/Loss', 'Date', 'Sport', 'Note'];
 
   const csvContent = [
     headers.join(','),
     ...bets.map(bet => [
       bet.outcome,
+      `"${bet.event}"`,
       `"${bet.description || ''}"`,
       bet.betType,
       bet.odds,
@@ -127,7 +128,6 @@ export function exportToCSV() {
       parseFloat(bet.payout).toFixed(2),
       bet.outcome === 'Pending' ? '' : parseFloat(bet.profitLoss).toFixed(2),
       formatDate(bet.date),
-      `"${bet.event}"`,
       bet.sport,
       `"${bet.note || ''}"`
     ].join(','))

--- a/js/render.js
+++ b/js/render.js
@@ -51,13 +51,18 @@ export function renderBets() {
     const profitClass = bet.profitLoss > 0 ? 'positive' : bet.profitLoss < 0 ? 'negative' : '';
     const profitSymbol = bet.profitLoss > 0 ? '+' : '';
 
-    row.innerHTML = `
-      <td>${bet.outcome}</td>
-      <td class="description-cell">
-        <div class="description-content" title="${bet.description || ''}" onclick="showFullText(${JSON.stringify(bet.description || '')})">
-          ${bet.description || ''}
-        </div>
-      </td>
+      row.innerHTML = `
+        <td>${bet.outcome}</td>
+        <td class="event-cell">
+          <div class="event-content" title="${bet.event}" onclick="showFullText(${JSON.stringify(bet.event)})">
+            ${bet.event}
+          </div>
+        </td>
+        <td class="description-cell">
+          <div class="description-content" title="${bet.description || ''}" onclick="showFullText(${JSON.stringify(bet.description || '')})">
+            ${bet.description || ''}
+          </div>
+        </td>
       <td>${bet.betType}</td>
       <td>${bet.odds}</td>
       <td>$${parseFloat(bet.stake).toFixed(2)}</td>
@@ -65,13 +70,8 @@ export function renderBets() {
       <td class="${profitClass}">
         ${bet.outcome === 'Pending' ? '—' : profitSymbol + '$' + parseFloat(bet.profitLoss).toFixed(2)}
       </td>
-      <td>${formatDate(bet.date)}</td>
-      <td class="event-cell">
-        <div class="event-content" title="${bet.event}" onclick="showFullText(${JSON.stringify(bet.event)})">
-          ${bet.event}
-        </div>
-      </td>
-      <td>${bet.sport}</td>
+        <td>${formatDate(bet.date)}</td>
+        <td>${bet.sport}</td>
       <td class="note-cell">
         <div class="note-content" title="${bet.note || ''}" onclick="showFullText(${JSON.stringify(bet.note || '')})">
           ${bet.note || ''}

--- a/shared/table.html
+++ b/shared/table.html
@@ -3,6 +3,7 @@
     <thead>
       <tr>
         <th>Outcome</th>
+        <th>Event</th>
         <th>Description</th>
         <th>Bet Type</th>
         <th>Odds</th>
@@ -10,7 +11,6 @@
         <th>Payout</th>
         <th>Profit/Loss</th>
         <th>Date</th>
-        <th>Event</th>
         <th>Sport</th>
         <th>Note</th>
         <th>Action</th>


### PR DESCRIPTION
## Summary
- Move Event column after Outcome in table headers
- Update table rendering logic to place Event column second
- Adjust CSV export to reflect new Event column order

## Testing
- `npm test`
- `node --check js/render.js`
- `node --check js/bets.js`


------
https://chatgpt.com/codex/tasks/task_e_689f986cb57483239e06fc4c181975cb