### PR TITLE
feat: add user stats

### DIFF
--- a/betting-tracker-backend/models/User.js
+++ b/betting-tracker-backend/models/User.js
@@ -3,7 +3,15 @@ const mongoose = require('mongoose');
 const UserSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   password: { type: String, required: true },
-  role: { type: String, enum: ['user', 'admin'], default: 'user' }
+  role: { type: String, enum: ['user', 'admin'], default: 'user' },
+  stats: {
+    totalBets: { type: Number, default: 0 },
+    winRate: { type: Number, default: 0 },
+    roi: { type: Number, default: 0 },
+    totalStaked: { type: Number, default: 0 },
+    totalReturn: { type: Number, default: 0 },
+    netProfit: { type: Number, default: 0 }
+  }
 });
 
 module.exports = mongoose.model('User', UserSchema);

--- a/betting-tracker-backend/routes/bets.js
+++ b/betting-tracker-backend/routes/bets.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const Bet = require('../models/Bet');
 const authorize = require('../middleware/authorize');
+const { updateUserStats } = require('../utils/userStats');
 
 // Get all bets for the authenticated user
 router.get('/', async (req, res) => {
@@ -14,6 +15,7 @@ router.post('/', async (req, res) => {
   try {
     const newBet = new Bet({ ...req.body, user: req.user.id });
     await newBet.save();
+    await updateUserStats(req.user.id);
     res.status(201).json(newBet);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -23,6 +25,7 @@ router.post('/', async (req, res) => {
 // Delete all bets for the authenticated user (admin only)
 router.delete('/', authorize('admin'), async (req, res) => {
   await Bet.deleteMany({ user: req.user.id });
+  await updateUserStats(req.user.id);
   res.json({ message: 'All bets deleted' });
 });
 
@@ -34,6 +37,7 @@ router.put('/:id', async (req, res) => {
       req.body,
       { new: true }
     );
+    await updateUserStats(req.user.id);
     res.json(updatedBet);
   } catch (err) {
     res.status(400).json({ error: err.message });
@@ -43,6 +47,7 @@ router.put('/:id', async (req, res) => {
 // Delete a bet for the authenticated user
 router.delete('/:id', async (req, res) => {
   await Bet.findOneAndDelete({ _id: req.params.id, user: req.user.id });
+  await updateUserStats(req.user.id);
   res.json({ message: 'Bet deleted' });
 });
 

--- a/betting-tracker-backend/routes/users.js
+++ b/betting-tracker-backend/routes/users.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const User = require('../models/User');
 const authorize = require('../middleware/authorize');
+const { updateUserStats } = require('../utils/userStats');
 
 const router = express.Router();
 
@@ -9,6 +10,17 @@ router.get('/', authorize('admin'), async (req, res) => {
   try {
     const users = await User.find().select('username');
     res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Get current user with stats
+router.get('/me', async (req, res) => {
+  try {
+    await updateUserStats(req.user.id);
+    const user = await User.findById(req.user.id).select('username stats');
+    res.json(user);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/betting-tracker-backend/scripts/updateUserStats.js
+++ b/betting-tracker-backend/scripts/updateUserStats.js
@@ -1,0 +1,22 @@
+const path = require('path');
+require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
+const mongoose = require('mongoose');
+const User = require('../models/User');
+const { updateUserStats } = require('../utils/userStats');
+
+async function run() {
+  try {
+    await mongoose.connect(process.env.MONGO_URI);
+    const users = await User.find();
+    for (const user of users) {
+      await updateUserStats(user._id);
+      console.log(`Updated stats for ${user.username}`);
+    }
+  } catch (err) {
+    console.error(err);
+  } finally {
+    await mongoose.disconnect();
+  }
+}
+
+run();

--- a/betting-tracker-backend/utils/userStats.js
+++ b/betting-tracker-backend/utils/userStats.js
@@ -1,0 +1,31 @@
+const Bet = require('../models/Bet');
+const User = require('../models/User');
+
+async function updateUserStats(userId) {
+  const bets = await Bet.find({ user: userId });
+  const settled = bets.filter(b => ['Win', 'Loss', 'Push'].includes(b.outcome));
+  const decided = bets.filter(b => b.outcome === 'Win' || b.outcome === 'Loss');
+  const wins = decided.filter(b => b.outcome === 'Win').length;
+  const totalStaked = settled.reduce((sum, b) => sum + (b.stake || 0), 0);
+  const totalReturn = settled.reduce((sum, b) => sum + (b.payout || 0), 0);
+  const netProfit = totalReturn - totalStaked;
+  const winRate = decided.length ? (wins / decided.length) * 100 : 0;
+  const roi = totalStaked > 0 ? (netProfit / totalStaked) * 100 : 0;
+
+  await User.findByIdAndUpdate(
+    userId,
+    {
+      stats: {
+        totalBets: bets.length,
+        winRate,
+        roi,
+        totalStaked,
+        totalReturn,
+        netProfit,
+      },
+    },
+    { new: true }
+  );
+}
+
+module.exports = { updateUserStats };

--- a/js/app.js
+++ b/js/app.js
@@ -11,7 +11,7 @@ window.removeBet = handleRemoveBet;
 window.loadDemoData = async () => {
   loadDemoBets();
   renderBets();
-  updateStats();
+  await updateStats();
 };
 window.settleBet = handleSettleBet;
 window.showFullText = showFullText;
@@ -33,5 +33,5 @@ window.addEventListener('shared:loaded', async () => {
   }
 
   renderBets();
-  updateStats();
+  await updateStats();
 });

--- a/js/form.js
+++ b/js/form.js
@@ -85,7 +85,7 @@ export async function handleAddBet() {
   try {
     await addBetData(bet);
     renderBets();
-    updateStats();
+    await updateStats();
     clearForm();
   } catch (err) {
     console.error('❌ Error adding bet:', err.message);
@@ -96,7 +96,7 @@ export async function handleClearAll() {
   if (confirm('Are you sure you want to clear all betting data? This cannot be undone.')) {
     await clearBets();
     renderBets();
-    updateStats();
+    await updateStats();
   }
 }
 

--- a/js/render.js
+++ b/js/render.js
@@ -5,7 +5,7 @@ import { formatDate } from './utils.js';
 export async function handleRemoveBet(id) {
   await removeBetData(id);
   renderBets();
-  updateStats();
+  await updateStats();
 }
 
 export async function handleSettleBet(selectEl, betId) {
@@ -13,7 +13,7 @@ export async function handleSettleBet(selectEl, betId) {
   if (!newOutcome) return;
   await settleBetData(betId, newOutcome);
   renderBets();
-  updateStats();
+  await updateStats();
 }
 
 export function renderBets() {

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,32 +1,45 @@
 import { bets } from './bets.js';
+import { API_BASE_URL } from './config.js';
 
-export function updateStats() {
+async function fetchUserStats() {
+  const token = localStorage.getItem('token');
+  if (!token) return null;
+  try {
+    const res = await fetch(`${API_BASE_URL}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error('Failed to fetch stats');
+    return await res.json();
+  } catch (err) {
+    console.error('❌ Error fetching user stats:', err.message);
+    return null;
+  }
+}
+
+export async function updateStats() {
+  const user = await fetchUserStats();
+
   const settled = bets.filter(b => ['Win', 'Loss', 'Push'].includes(b.outcome));
   const decided = bets.filter(b => b.outcome === 'Win' || b.outcome === 'Loss');
-  const wins = decided.filter(b => b.outcome === 'Win').length;
-  const totalStaked = settled.reduce((sum, b) => sum + b.stake, 0);
-  const totalReturn = settled.reduce((sum, b) => sum + b.payout, 0);
-  const netProfit = totalReturn - totalStaked;
-  const roi = totalStaked > 0 ? (netProfit / totalStaked * 100).toFixed(1) : 0;
-  const avgStake = settled.length ? (totalStaked / settled.length).toFixed(2) : '0.00';
+  const avgStake = settled.length ? (settled.reduce((sum, b) => sum + b.stake, 0) / settled.length).toFixed(2) : '0.00';
 
   const el = id => document.getElementById(id);
 
-  if (el('totalBets')) el('totalBets').textContent = bets.length;
-  if (el('winRate')) el('winRate').textContent = decided.length ? ((wins / decided.length) * 100).toFixed(1) + '%' : '0%';
-  if (el('totalStaked')) el('totalStaked').textContent = '$' + totalStaked.toFixed(2);
-  if (el('totalReturn')) el('totalReturn').textContent = '$' + totalReturn.toFixed(2);
-
-  if (el('netProfit')) {
-    el('netProfit').textContent = (netProfit >= 0 ? '+' : '') + '$' + netProfit.toFixed(2);
-    el('netProfit').className = 'stat-value ' + (netProfit >= 0 ? 'positive' : 'negative');
+  if (user?.stats) {
+    const { totalBets, winRate, totalStaked, totalReturn, netProfit, roi } = user.stats;
+    if (el('totalBets')) el('totalBets').textContent = totalBets;
+    if (el('winRate')) el('winRate').textContent = winRate.toFixed(1) + '%';
+    if (el('totalStaked')) el('totalStaked').textContent = '$' + totalStaked.toFixed(2);
+    if (el('totalReturn')) el('totalReturn').textContent = '$' + totalReturn.toFixed(2);
+    if (el('netProfit')) {
+      el('netProfit').textContent = (netProfit >= 0 ? '+' : '') + '$' + netProfit.toFixed(2);
+      el('netProfit').className = 'stat-value ' + (netProfit >= 0 ? 'positive' : 'negative');
+    }
+    if (el('roi')) {
+      el('roi').textContent = (roi >= 0 ? '+' : '') + roi.toFixed(1) + '%';
+      el('roi').className = 'stat-value ' + (roi >= 0 ? 'positive' : 'negative');
+    }
   }
-
-  if (el('roi')) {
-    el('roi').textContent = (roi >= 0 ? '+' : '') + roi + '%';
-    el('roi').className = 'stat-value ' + (roi >= 0 ? 'positive' : 'negative');
-  }
-
 
   const profitBySport = {};
   for (let b of settled) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vercel dev",
     "start": "node api/index.js",
     "test": "echo \"No tests\"",
-    "migrate:bet-users": "node scripts/assignUserToBets.js"
+    "migrate:bet-users": "node scripts/assignUserToBets.js",
+    "migrate:user-stats": "node betting-tracker-backend/scripts/updateUserStats.js"
   },
   "dependencies": {
     "bcrypt": "^5.1.1",


### PR DESCRIPTION
## Summary
- store betting statistics on the user document
- expose current user stats API and keep stats updated when bets change
- display persisted stats in UI and add migration script to backfill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a09fcc3e748323858f8e70f6590d5a