### PR TITLE
Refine tracker icon and add bet detail modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -69,10 +69,21 @@ body {
     gap: 10px;
   }
 
-  .header .nav-icon-links a {
+  .header .nav-icon-links .icon-btn {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255,255,255,0.1);
+    border-radius: 4px;
+  }
+
+  .header .nav-icon-links .icon-btn a {
     color: white;
     text-decoration: none;
     font-size: 20px;
+    line-height: 1;
   }
 
  .header .learn-more-link {
@@ -137,7 +148,7 @@ body {
     gap: 10px;
   }
 
-  .header .nav-icon-links a {
+  .header .nav-icon-links .icon-btn a {
     font-size: 24px;
   }
 }
@@ -337,4 +348,16 @@ tr:hover {
 
 .modal-close {
   margin-top: 10px;
+}
+
+.bet-details-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 20px;
+}
+
+@media (max-width: 500px) {
+  .bet-details-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,13 +1,72 @@
+import { formatDate } from './utils.js';
+
+let activeModal = null;
+
+function handleKeyDown(e) {
+  if (!activeModal) return;
+  const focusable = activeModal.querySelectorAll(
+    'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+
+  if (e.key === 'Tab') {
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  } else if (e.key === 'Escape') {
+    closeModal();
+  }
+}
+
+function openModal(modal) {
+  activeModal = modal;
+  modal.classList.add('active');
+  modal.addEventListener('keydown', handleKeyDown);
+  const focusable = modal.querySelectorAll(
+    'a, button, input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  if (focusable[0]) focusable[0].focus();
+}
+
+export function closeModal() {
+  if (!activeModal) return;
+  activeModal.classList.remove('active');
+  activeModal.removeEventListener('keydown', handleKeyDown);
+  activeModal = null;
+}
+
 export function showFullText(text) {
   const modal = document.getElementById('textModal');
   const modalText = document.getElementById('modalText');
   if (modal && modalText) {
     modalText.textContent = text || '';
-    modal.classList.add('active');
+    openModal(modal);
   }
 }
 
-export function closeModal() {
-  const modal = document.getElementById('textModal');
-  if (modal) modal.classList.remove('active');
+export function showBetDetails(bet) {
+  const modal = document.getElementById('betDetailsModal');
+  const body = document.getElementById('betDetailsBody');
+  if (modal && body) {
+    body.innerHTML = `
+      <div><strong>Outcome:</strong> ${bet.outcome}</div>
+      <div><strong>Description:</strong> ${bet.description || ''}</div>
+      <div><strong>Bet Type:</strong> ${bet.betType}</div>
+      <div><strong>Odds:</strong> ${bet.odds}</div>
+      <div><strong>Stake:</strong> $${parseFloat(bet.stake).toFixed(2)}</div>
+      <div><strong>Payout:</strong> $${parseFloat(bet.payout).toFixed(2)}</div>
+      <div><strong>Profit/Loss:</strong> ${bet.outcome === 'Pending' ? '—' : (bet.profitLoss > 0 ? '+' : '') + '$' + parseFloat(bet.profitLoss).toFixed(2)}</div>
+      <div><strong>Date:</strong> ${formatDate(bet.date)}</div>
+      <div><strong>Event:</strong> ${bet.event}</div>
+      <div><strong>Sport:</strong> ${bet.sport}</div>
+      <div><strong>Note:</strong> ${bet.note || ''}</div>
+    `;
+    openModal(modal);
+  }
 }
+

--- a/js/render.js
+++ b/js/render.js
@@ -1,6 +1,7 @@
 import { bets, removeBet as removeBetData, settleBet as settleBetData } from './bets.js';
 import { updateStats } from './stats.js';
 import { formatDate } from './utils.js';
+import { showBetDetails } from './modal.js';
 
 export async function handleRemoveBet(id) {
   await removeBetData(id);
@@ -47,6 +48,7 @@ export function renderBets() {
   sorted.forEach(bet => {
     const row = document.createElement('tr');
     row.className = bet.outcome.toLowerCase();
+    row.tabIndex = 0;
 
     const profitClass = bet.profitLoss > 0 ? 'positive' : bet.profitLoss < 0 ? 'negative' : '';
     const profitSymbol = bet.profitLoss > 0 ? '+' : '';
@@ -93,6 +95,17 @@ export function renderBets() {
         }
       </td>
     `;
+
+    row.addEventListener('click', e => {
+      if (e.target.closest('button') || e.target.closest('select')) return;
+      showBetDetails(bet);
+    });
+    row.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        showBetDetails(bet);
+      }
+    });
 
     tbody.appendChild(row);
   });

--- a/shared/header.html
+++ b/shared/header.html
@@ -1,12 +1,12 @@
 <div class="header">
   <nav class="top-nav">
     <div class="nav-icon-links">
-      <a href="index.html" aria-label="Tracker">📊</a>
-      <a href="profile.html" aria-label="Profile">👤</a>
+      <div class="icon-btn"><a href="index.html" aria-label="Tracker">📋</a></div>
+      <div class="icon-btn"><a href="profile.html" aria-label="Profile">👤</a></div>
     </div>
 
     <div class="nav-links">
-      <a href="index.html">📊 Tracker</a>
+      <a href="index.html">📋 Tracker</a>
       <a href="profile.html">👤 Profile</a>
       <a href="settings.html">⚙️ Settings</a>
       <a href="admin.html">🛠️ Admin</a>

--- a/shared/modal.html
+++ b/shared/modal.html
@@ -5,3 +5,12 @@
     <button class="btn modal-close" onclick="closeModal()">Close</button>
   </div>
 </div>
+
+<!-- Modal for viewing bet details -->
+<div id="betDetailsModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="betDetailsTitle" onclick="closeModal()">
+  <div class="modal-content" tabindex="-1" onclick="event.stopPropagation();">
+    <h2 id="betDetailsTitle">Bet Details</h2>
+    <div id="betDetailsBody" class="bet-details-grid"></div>
+    <button class="btn modal-close" onclick="closeModal()">Close</button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- replace tracker bar graph emoji with clipboard and wrap mobile nav icons in uniform button containers
- enable table row click to open accessible modal showing bet details
- style bet detail modal with responsive grid layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0aabc2c288323a1259d271158805f