### PR TITLE
Add navigation links and improve modal UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -219,6 +219,15 @@ body {
   font-size: 14px;
 }
 
+.auth-link {
+  margin-top: 10px;
+  font-size: 14px;
+}
+
+.auth-link a {
+  color: #3498db;
+}
+
 .btn {
   background: #3498db;
   color: white;
@@ -326,7 +335,7 @@ tr:hover {
   left: 0;
   width: 100%;
   height: 100%;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.7);
   display: none;
   align-items: center;
   justify-content: center;
@@ -338,16 +347,38 @@ tr:hover {
 }
 
 .modal-content {
-  background: white;
-  padding: 20px;
+  position: relative;
+  background: #fff;
+  padding: 30px;
   border-radius: 8px;
-  max-width: 90%;
+  max-width: 500px;
+  width: 90%;
   max-height: 80%;
   overflow-y: auto;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+  transform: translateY(-20px);
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.modal.active .modal-content {
+  transform: translateY(0);
+  opacity: 1;
 }
 
 .modal-close {
-  margin-top: 10px;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #555;
+}
+
+.modal-close:hover {
+  color: #000;
 }
 
 .bet-details-grid {

--- a/login.html
+++ b/login.html
@@ -24,6 +24,7 @@
         </div>
         <button class="btn" type="submit">Login</button>
       </form>
+      <p class="auth-link">Don't have an account? <a href="register.html">Sign up</a></p>
     </div>
   </div>
   <script src="js/loadShared.js"></script>

--- a/register.html
+++ b/register.html
@@ -24,6 +24,7 @@
         </div>
         <button class="btn" type="submit">Register</button>
       </form>
+      <p class="auth-link">Already have an account? <a href="login.html">Log in</a></p>
     </div>
   </div>
   <script src="js/loadShared.js"></script>

--- a/shared/modal.html
+++ b/shared/modal.html
@@ -1,16 +1,16 @@
 <!-- Modal for viewing full text -->
 <div id="textModal" class="modal" onclick="closeModal()">
   <div class="modal-content" onclick="event.stopPropagation();">
+    <button class="modal-close" onclick="closeModal()" aria-label="Close">&times;</button>
     <div id="modalText"></div>
-    <button class="btn modal-close" onclick="closeModal()">Close</button>
   </div>
 </div>
 
 <!-- Modal for viewing bet details -->
 <div id="betDetailsModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="betDetailsTitle" onclick="closeModal()">
   <div class="modal-content" tabindex="-1" onclick="event.stopPropagation();">
+    <button class="modal-close" onclick="closeModal()" aria-label="Close">&times;</button>
     <h2 id="betDetailsTitle">Bet Details</h2>
     <div id="betDetailsBody" class="bet-details-grid"></div>
-    <button class="btn modal-close" onclick="closeModal()">Close</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add cross-links between login and registration pages
- enhance modal styling with close icon and animations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0e13f55ec8323aa7e8495bf9d218b