### PR TITLE
Add demo bets and stats for profile demo mode

### DIFF
--- a/js/bets.js
+++ b/js/bets.js
@@ -186,6 +186,76 @@ export function loadDemoData() {
       date: '2024-03-10T00:00:00.000Z',
       sport: 'Baseball',
       note: ''
+    },
+    {
+      _id: 'demo-4',
+      outcome: 'Win',
+      event: 'Packers vs Bears',
+      description: 'Packers ML',
+      betType: 'Moneyline',
+      odds: '+120',
+      stake: 100,
+      payout: calculatePayout('+120', 100),
+      profitLoss: calculatePayout('+120', 100) - 100,
+      date: '2024-04-12T00:00:00.000Z',
+      sport: 'NFL Football',
+      note: 'Dog hits'
+    },
+    {
+      _id: 'demo-5',
+      outcome: 'Loss',
+      event: 'Knicks vs Bulls',
+      description: 'Over 210.5',
+      betType: 'Over/Under',
+      odds: '-110',
+      stake: 110,
+      payout: 0,
+      profitLoss: -110,
+      date: '2024-05-01T00:00:00.000Z',
+      sport: 'NBA Basketball',
+      note: 'High scoring attempt'
+    },
+    {
+      _id: 'demo-6',
+      outcome: 'Pending',
+      event: 'Patriots vs Dolphins',
+      description: 'Under 43.5',
+      betType: 'Over/Under',
+      odds: '-105',
+      stake: 105,
+      payout: 0,
+      profitLoss: 0,
+      date: '2024-06-15T00:00:00.000Z',
+      sport: 'NFL Football',
+      note: ''
+    },
+    {
+      _id: 'demo-7',
+      outcome: 'Win',
+      event: 'Hurricanes vs Penguins',
+      description: 'Hurricanes +1.5',
+      betType: 'Puck Line',
+      odds: '-130',
+      stake: 130,
+      payout: calculatePayout('-130', 130),
+      profitLoss: calculatePayout('-130', 130) - 130,
+      date: '2024-07-20T00:00:00.000Z',
+      sport: 'NHL Hockey',
+      note: 'Sample hockey win'
+    },
+    {
+      _id: 'demo-8',
+      outcome: 'Push',
+      event: 'Spain vs France',
+      description: 'Spain +1',
+      betType: 'Point Spread',
+      odds: '-110',
+      stake: 110,
+      payout: 110,
+      profitLoss: 0,
+      date: '2024-08-05T00:00:00.000Z',
+      sport: 'Soccer',
+      note: 'Push sample'
     }
   ];
 }

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,5 +1,6 @@
 
 import { API_BASE_URL } from './config.js';
+import { bets } from './bets.js';
 
 async function fetchUserStats() {
   const token = localStorage.getItem('token');
@@ -17,12 +18,63 @@ async function fetchUserStats() {
   }
 }
 
+function calculateDemoStats() {
+  const settled = bets.filter(b => ['Win', 'Loss', 'Push'].includes(b.outcome));
+  const decided = bets.filter(b => b.outcome === 'Win' || b.outcome === 'Loss');
+  const wins = decided.filter(b => b.outcome === 'Win').length;
+  const totalStaked = settled.reduce((sum, b) => sum + (b.stake || 0), 0);
+  const totalReturn = settled.reduce((sum, b) => sum + (b.payout || 0), 0);
+  const netProfit = totalReturn - totalStaked;
+  const winRate = decided.length ? (wins / decided.length) * 100 : 0;
+  const roi = totalStaked > 0 ? (netProfit / totalStaked) * 100 : 0;
+  const avgStake = settled.length ? totalStaked / settled.length : 0;
+
+  const profitBySport = {};
+  for (const b of settled) {
+    const profit = b.profitLoss || 0;
+    profitBySport[b.sport] = (profitBySport[b.sport] || 0) + profit;
+  }
+  const mostProfitable = Object.entries(profitBySport).sort((a, b) => b[1] - a[1])[0]?.[0] || '-';
+
+  let streak = 0;
+  let maxStreak = 0;
+  for (const b of settled) {
+    if (b.outcome === 'Win') {
+      streak++;
+      if (streak > maxStreak) maxStreak = streak;
+    } else if (b.outcome === 'Loss') {
+      streak = 0;
+    }
+  }
+  const winStreak = maxStreak;
+
+  return {
+    totalBets: bets.length,
+    winRate,
+    roi,
+    totalStaked,
+    totalReturn,
+    netProfit,
+    mostProfitable,
+    avgStake,
+    winStreak,
+  };
+}
 
 export async function updateStats() {
-  const user = await fetchUserStats();
+  const isDemoMode = new URLSearchParams(window.location.search).get('demo');
+  const token = localStorage.getItem('token');
   const el = id => document.getElementById(id);
 
-  if (user?.stats) {
+  let stats = null;
+  if (!token || isDemoMode) {
+    stats = calculateDemoStats();
+  } else {
+    const user = await fetchUserStats();
+    stats = user?.stats;
+  }
+
+  if (stats) {
     const {
       totalBets,
       winRate,
@@ -33,7 +85,7 @@ export async function updateStats() {
       mostProfitable,
       avgStake,
       winStreak,
-    } = user.stats;
+    } = stats;
     if (el('totalBets')) el('totalBets').textContent = totalBets;
     if (el('winRate')) el('winRate').textContent = winRate.toFixed(1) + '%';
     if (el('totalStaked')) el('totalStaked').textContent = '$' + totalStaked.toFixed(2);
@@ -45,7 +97,6 @@ export async function updateStats() {
     if (el('roi')) {
       el('roi').textContent = (roi >= 0 ? '+' : '') + roi.toFixed(1) + '%';
       el('roi').className = 'stat-value ' + (roi >= 0 ? 'positive' : 'negative');
-
     }
     if (el('bestSport')) el('bestSport').textContent = mostProfitable || '-';
     if (el('avgStake')) el('avgStake').textContent = '$' + avgStake.toFixed(2);


### PR DESCRIPTION
## Summary
- expand demo mode bet list to eight sample bets
- calculate demo statistics from local bets when not authenticated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a16ee9f8e88323b2fb85fa10365584