### PR TITLE
Add Soccer and NHL Hockey options and move bet actions to modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -450,6 +450,17 @@ tr:hover {
   margin-top: 20px;
 }
 
+.modal-actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.modal-actions select {
+  padding: 8px;
+}
+
 .detail-card {
   background: #f8f9fa;
   border-radius: 10px;

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
             <option value="College Basketball">College Basketball</option>
             <option value="Baseball">Baseball</option>
             <option value="College Football">College Football</option>
+            <option value="NHL Hockey">NHL Hockey</option>
+            <option value="Soccer">Soccer</option>
             <option value="Premier League">Premier League</option>
             <option value="La Liga">La Liga</option>
             <option value="Bundesliga">Bundesliga</option>

--- a/js/modal.js
+++ b/js/modal.js
@@ -100,6 +100,22 @@ export function showBetDetails(bet) {
       body.appendChild(card);
     });
 
+    const actions = document.createElement('div');
+    actions.className = 'modal-actions';
+    actions.innerHTML =
+      bet.outcome === 'Pending'
+        ? `
+          <select onchange="settleBet(this, '${bet._id}'); closeModal();">
+            <option value="">Settle</option>
+            <option value="Win">Win</option>
+            <option value="Loss">Loss</option>
+            <option value="Push">Push</option>
+          </select>
+          <button class="btn btn-danger" onclick="removeBet('${bet._id}'); closeModal();">Remove</button>
+        `
+        : `<button class="btn btn-danger" onclick="removeBet('${bet._id}'); closeModal();">Remove</button>`;
+    body.appendChild(actions);
+
     openModal(modal);
   }
 }

--- a/js/render.js
+++ b/js/render.js
@@ -73,31 +73,15 @@ export function renderBets() {
         ${bet.outcome === 'Pending' ? '—' : profitSymbol + '$' + parseFloat(bet.profitLoss).toFixed(2)}
       </td>
         <td>${formatDate(bet.date)}</td>
-        <td>${bet.sport}</td>
+      <td>${bet.sport}</td>
       <td class="note-cell">
         <div class="note-content" title="${bet.note || ''}" onclick="showFullText(${JSON.stringify(bet.note || '')})">
           ${bet.note || ''}
         </div>
       </td>
-      <td>
-        ${
-          bet.outcome === 'Pending'
-            ? `
-              <select onchange="settleBet(this, '${bet._id}')">
-                <option value="">Settle</option>
-                <option value="Win">Win</option>
-                <option value="Loss">Loss</option>
-                <option value="Push">Push</option>
-              </select>
-              <button class="btn btn-danger" onclick="removeBet('${bet._id}')">Remove</button>
-            `
-            : `<button class="btn btn-danger" onclick="removeBet('${bet._id}')">Remove</button>`
-        }
-      </td>
     `;
 
-    row.addEventListener('click', e => {
-      if (e.target.closest('button') || e.target.closest('select')) return;
+    row.addEventListener('click', () => {
       showBetDetails(bet);
     });
     row.addEventListener('keydown', e => {

--- a/shared/table.html
+++ b/shared/table.html
@@ -13,7 +13,6 @@
         <th>Date</th>
         <th>Sport</th>
         <th>Note</th>
-        <th>Action</th>
       </tr>
     </thead>
     <tbody id="betsTable">


### PR DESCRIPTION
## Summary
- add Soccer and NHL Hockey to sport selection list
- remove Action column in bet table and handle actions in modal
- add modal action controls and styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a172c423bc83239d6d0836edc46019