### PR TITLE
feat: add learn more modal

### DIFF
--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -52,6 +52,18 @@ async function loadSharedComponents() {
             navLinks.classList.toggle('open');
           });
         }
+
+        const learnMoreLink = target.querySelector('#learn-more-link');
+        if (learnMoreLink) {
+          learnMoreLink.addEventListener('click', (e) => {
+            e.preventDefault();
+            const text =
+              'Track your bets meticulously for better bankroll management. Keeping detailed records allows you to analyze performance, discover patterns, and maintain discipline.';
+            if (window.showFullText) {
+              window.showFullText(text, 'About This Tracker');
+            }
+          });
+        }
       }
 
       // Profile-specific behavior

--- a/js/modal.js
+++ b/js/modal.js
@@ -58,11 +58,13 @@ export function closeModal(event) {
   activeModal = null;
 }
 
-export function showFullText(text) {
+export function showFullText(text, title = 'Full Text') {
   const modal = document.getElementById('textModal');
   const modalText = document.getElementById('modalText');
-  if (modal && modalText) {
+  const modalTitle = document.getElementById('textModalTitle');
+  if (modal && modalText && modalTitle) {
     modalText.textContent = text || '';
+    modalTitle.innerHTML = `<span class="modal-icon">📄</span>${title}`;
     openModal(modal);
   }
 }

--- a/shared/header.html
+++ b/shared/header.html
@@ -15,5 +15,5 @@
   </nav>
   <h1 id="page-title">🎯 Performance Tracker</h1>
   <p id="page-subtitle">Track your bets meticulously for better bankroll management</p>
-  <a href="profile.html" id="learn-more-link" class="learn-more-link">Learn More</a>
+  <a href="#" id="learn-more-link" class="learn-more-link">Learn More</a>
 </div>


### PR DESCRIPTION
## Summary
- open an informational modal when clicking the header's Learn More link
- allow `showFullText` to accept custom titles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1fdc2519c8323adce03eb38df8feb