### PR TITLE
feat: add dual local and server storage

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,9 +113,7 @@
     <!-- DOWNLOAD -->
     <div class="download-section">
       <button class="btn" onclick="exportToCSV()">📊 Export to CSV</button>
-      <p style="margin-top: 10px; color: #7f8c8d; font-size: 12px;">
-        This tracker runs in your browser. Data is saved locally and will persist between sessions.
-      </p>
+      <p id="storage-msg" style="margin-top: 10px; color: #7f8c8d; font-size: 12px;"></p>
     </div>
   </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -25,9 +25,8 @@ initForm();
 // Wait for shared HTML components before loading bets
 window.addEventListener('shared:loaded', async () => {
   const isDemoMode = new URLSearchParams(window.location.search).get('demo');
-  const token = localStorage.getItem('token');
 
-  if (isDemoMode || !token) {
+  if (isDemoMode) {
     loadDemoBets();
   } else {
     await fetchBets();

--- a/js/auth.js
+++ b/js/auth.js
@@ -5,6 +5,7 @@ function updateAuthUI() {
   const logoutBtn = document.getElementById('logout-btn');
   const addBetBtn = document.getElementById('add-bet-btn');
   const signInBtn = document.getElementById('sign-in-btn');
+  const storageMsg = document.getElementById('storage-msg');
 
   const token = localStorage.getItem('token');
   const isLoggedIn = Boolean(token);
@@ -21,10 +22,12 @@ function updateAuthUI() {
     }
     if (addBetBtn) addBetBtn.style.display = 'inline-block';
     if (signInBtn) signInBtn.style.display = 'none';
+    if (storageMsg) storageMsg.textContent = 'Your data is synced to your account and accessible on any device.';
   } else {
     if (logoutBtn) logoutBtn.style.display = 'none';
-    if (addBetBtn) addBetBtn.style.display = 'none';
+    if (addBetBtn) addBetBtn.style.display = 'inline-block';
     if (signInBtn) signInBtn.style.display = 'inline-block';
+    if (storageMsg) storageMsg.textContent = 'Your data is saved locally and will persist between sessions. Sign up to sync across devices.';
   }
 }
 

--- a/js/form.js
+++ b/js/form.js
@@ -68,7 +68,6 @@ export async function handleAddBet() {
   }
 
   const bet = {
-    id: Date.now(),
     date,
     sport,
     event,

--- a/js/login.js
+++ b/js/login.js
@@ -1,4 +1,5 @@
 import { API_BASE_URL } from './config.js';
+import { mergeLocalBets } from './bets.js';
 
 document.getElementById('login-form').addEventListener('submit', async (e) => {
   e.preventDefault();
@@ -16,6 +17,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
 
     const data = await res.json();
     localStorage.setItem('token', data.token);
+    await mergeLocalBets();
     window.location.href = 'index.html';
   } catch (err) {
     console.error('❌ Login error:', err.message);

--- a/js/stats.js
+++ b/js/stats.js
@@ -69,9 +69,17 @@ export async function updateStats() {
   let stats = null;
   if (!token || isDemoMode) {
     stats = calculateDemoStats();
+    localStorage.setItem('stats', JSON.stringify(stats));
   } else {
     const user = await fetchUserStats();
     stats = user?.stats;
+    if (!stats) {
+      // API failed, fallback to local
+      stats = calculateDemoStats();
+      localStorage.setItem('stats', JSON.stringify(stats));
+    } else {
+      localStorage.removeItem('stats');
+    }
   }
 
   if (stats) {


### PR DESCRIPTION
## Summary
- persist bets locally for guests and fall back to local data if API calls fail
- merge locally stored bets into database on login
- show storage mode message and allow guests to add bets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23523dc7c83238378dcdc1050dc6f