### PR TITLE
feat: allow clearing all bets from settings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,16 @@
+import { clearBets } from './bets.js';
+import { renderBets } from './render.js';
+import { updateStats } from './stats.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const resetBtn = document.getElementById('reset-bets-btn');
+  if (!resetBtn) return;
+
+  resetBtn.addEventListener('click', async () => {
+    if (!confirm('Are you sure you want to clear all bets?')) return;
+    await clearBets();
+    renderBets();
+    await updateStats();
+    alert('All bets have been cleared.');
+  });
+});

--- a/settings.html
+++ b/settings.html
@@ -19,11 +19,16 @@
           <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
           <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
         </div>
+        <div class="data-controls">
+          <h3>Data</h3>
+          <button class="btn btn-danger" id="reset-bets-btn">Clear All Bets</button>
+        </div>
       </div>
     </div>
 
     <script src="js/loadShared.js"></script>
     <script type="module" src="js/app.js"></script>
+    <script type="module" src="js/settings.js"></script>
     <script src="js/auth.js"></script>
   <script>
     window.addEventListener('shared:loaded', () => {


### PR DESCRIPTION
## Summary
- add controls in settings page to let users clear all bets
- implement settings script to trigger bet reset and update stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a347a52d90832387b66881c2ae7778