### PR TITLE
Preserve bet form data through login

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 import { bets, fetchBets, loadDemoData as loadDemoBets, exportToCSV } from './bets.js';
-import { initForm, handleAddBet } from './form.js';
+import { initForm, handleAddBet, saveFormData } from './form.js';
 import { renderBets, handleRemoveBet, handleSettleBet } from './render.js';
 import { updateStats } from './stats.js';
 import { showFullText, closeModal, showLearnMore } from './modal.js';
@@ -18,6 +18,7 @@ window.closeModal = closeModal;
 window.showLearnMore = showLearnMore;
 window.exportToCSV = exportToCSV;
 window.renderBets = renderBets;
+window.saveFormData = saveFormData;
 
 // Initialize form handlers
 initForm();

--- a/js/auth.js
+++ b/js/auth.js
@@ -28,7 +28,14 @@ function updateAuthUI() {
   } else {
     if (logoutBtn) logoutBtn.style.display = 'none';
     if (addBetBtn) addBetBtn.style.display = 'none';
-    if (signInBtn) signInBtn.style.display = 'inline-block';
+    if (signInBtn) {
+      signInBtn.style.display = 'inline-block';
+      signInBtn.addEventListener('click', () => {
+        if (typeof window.saveFormData === 'function') {
+          window.saveFormData();
+        }
+      }, { once: true });
+    }
   }
 }
 

--- a/js/form.js
+++ b/js/form.js
@@ -2,6 +2,8 @@ import { addBet as addBetData, calculatePayout } from './bets.js';
 import { renderBets } from './render.js';
 import { updateStats } from './stats.js';
 
+const FORM_FIELDS = ['date', 'sport', 'event', 'betType', 'odds', 'stake', 'outcome', 'description', 'note'];
+
 export function initForm() {
   const outcomeEl = document.getElementById('outcome');
   const oddsEl = document.getElementById('odds');
@@ -10,6 +12,40 @@ export function initForm() {
     outcomeEl.addEventListener('change', updatePayoutPreview);
     oddsEl.addEventListener('input', updatePayoutPreview);
     stakeEl.addEventListener('input', updatePayoutPreview);
+  }
+
+  restoreFormData();
+}
+
+export function saveFormData() {
+  const data = {};
+  FORM_FIELDS.forEach(id => {
+    const el = document.getElementById(id);
+    if (el && el.value) data[id] = el.value;
+  });
+  try {
+    localStorage.setItem('pendingBet', JSON.stringify(data));
+  } catch (err) {
+    console.error('❌ Error saving form data:', err.message);
+  }
+}
+
+function restoreFormData() {
+  try {
+    const raw = localStorage.getItem('pendingBet');
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    FORM_FIELDS.forEach(id => {
+      const el = document.getElementById(id);
+      if (el && data[id] !== undefined) {
+        el.value = data[id];
+      }
+    });
+    updatePayoutPreview();
+  } catch (err) {
+    console.error('❌ Error restoring form data:', err.message);
+  } finally {
+    localStorage.removeItem('pendingBet');
   }
 }
 


### PR DESCRIPTION
## Summary
- Store bet form inputs in localStorage before redirecting to sign in
- Restore saved form data after authentication so users don't lose work
- Hook sign-in button to trigger form data persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a35fb315dc8323b52b19fceff6ffb4