### PR TITLE
Move CSV export to Settings page

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,13 +110,6 @@
     <!-- TABLE -->
     <div id="include-table"></div>
 
-    <!-- DOWNLOAD -->
-    <div class="download-section">
-      <button class="btn" onclick="exportToCSV()">📊 Export to CSV</button>
-      <p style="margin-top: 10px; color: #7f8c8d; font-size: 12px;">
-        This tracker runs in your browser. Data is saved locally and will persist between sessions.
-      </p>
-    </div>
   </div>
 
   <!-- MODAL -->

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,16 +1,21 @@
-import { clearBets } from './bets.js';
+import { clearBets, exportToCSV } from './bets.js';
 import { renderBets } from './render.js';
 import { updateStats } from './stats.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const resetBtn = document.getElementById('reset-bets-btn');
-  if (!resetBtn) return;
+  if (resetBtn) {
+    resetBtn.addEventListener('click', async () => {
+      if (!confirm('Are you sure you want to clear all bets?')) return;
+      await clearBets();
+      renderBets();
+      await updateStats();
+      alert('All bets have been cleared.');
+    });
+  }
 
-  resetBtn.addEventListener('click', async () => {
-    if (!confirm('Are you sure you want to clear all bets?')) return;
-    await clearBets();
-    renderBets();
-    await updateStats();
-    alert('All bets have been cleared.');
-  });
+  const exportBtn = document.getElementById('export-bets-btn');
+  if (exportBtn) {
+    exportBtn.addEventListener('click', exportToCSV);
+  }
 });

--- a/settings.html
+++ b/settings.html
@@ -21,6 +21,7 @@
         </div>
         <div class="data-controls">
           <h3>Data</h3>
+          <button class="btn" id="export-bets-btn">Export Bets to CSV</button>
           <button class="btn btn-danger" id="reset-bets-btn">Clear All Bets</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Relocate CSV export controls from the main page to the Settings page.
- Remove browser data persistence notice from the main tracker page.
- Wire up new export button in Settings via dedicated script.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a398f56124832381aeedecc24808b9