### PR TITLE
Add bottom spacing to betting table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -265,6 +265,7 @@ body {
   overflow-x: auto;
   max-height: 500px;
   overflow-y: auto;
+  padding-bottom: 20px;
 }
 
 table {


### PR DESCRIPTION
## Summary
- add bottom padding to table container so table rows don't touch the page edge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3b0b655848323bdf51d4f4318304f