### PR TITLE
Expand note field in bet details modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -505,6 +505,10 @@ tr:hover {
   transition: all 0.2s ease;
 }
 
+.detail-card.full-width {
+  grid-column: 1 / -1;
+}
+
 .detail-card:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   transform: translateY(-1px);

--- a/js/modal.js
+++ b/js/modal.js
@@ -86,7 +86,7 @@ export function showBetDetails(bet) {
       { label: 'Date', value: formatDate(bet.date), class: '' },
       { label: 'Event', value: bet.event, class: '' },
       { label: 'Sport', value: bet.sport, class: '' },
-      { label: 'Note', value: bet.note || '', class: '' }
+      { label: 'Note', value: bet.note || '', class: '', fullWidth: true }
     ];
 
     body.innerHTML = '';
@@ -109,6 +109,7 @@ export function showBetDetails(bet) {
     details.forEach(detail => {
       const card = document.createElement('div');
       card.className = 'detail-card';
+      if (detail.fullWidth) card.classList.add('full-width');
       card.innerHTML = `
         <div class="detail-label">${detail.label}</div>
         <div class="detail-value ${detail.class}">${detail.value}</div>


### PR DESCRIPTION
## Summary
- allow the Note entry in bet details modal to span the full grid width for better readability on larger screens
- add `full-width` CSS class and apply it when rendering note details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3c4fef2148323bb074a85ac31257f