### PR TITLE
Improve auth security with validation and rate limiting

### DIFF
--- a/betting-tracker-backend/routes/auth.js
+++ b/betting-tracker-backend/routes/auth.js
@@ -3,6 +3,30 @@ const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 
+// Password must contain at least 8 characters including uppercase,
+// lowercase, number and special character
+const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,}$/;
+
+// Track login attempts per IP to throttle repeated failures
+const loginAttempts = {};
+const windowMs = 60 * 1000; // 1 minute
+const maxAttempts = 5;
+
+function loginRateLimiter(req, res, next) {
+  const ip = req.ip;
+  const now = Date.now();
+  if (!loginAttempts[ip]) loginAttempts[ip] = [];
+  // Remove timestamps outside the window
+  loginAttempts[ip] = loginAttempts[ip].filter((ts) => now - ts < windowMs);
+  if (loginAttempts[ip].length >= maxAttempts) {
+    return res
+      .status(429)
+      .json({ error: 'Too many login attempts, please try again later.' });
+  }
+  loginAttempts[ip].push(now);
+  next();
+}
+
 const router = express.Router();
 
 router.post('/register', async (req, res) => {
@@ -10,6 +34,12 @@ router.post('/register', async (req, res) => {
     const { username, password, role } = req.body;
     if (!username || !password) {
       return res.status(400).json({ error: 'Username and password are required' });
+    }
+    if (!passwordRegex.test(password)) {
+      return res.status(400).json({
+        error:
+          'Password must be at least 8 characters and include uppercase, lowercase, number and special character'
+      });
     }
     let user = await User.findOne({ username });
     if (user) {
@@ -29,7 +59,7 @@ router.post('/register', async (req, res) => {
   }
 });
 
-router.post('/login', async (req, res) => {
+router.post('/login', loginRateLimiter, async (req, res) => {
   try {
     const { username, password } = req.body;
     const user = await User.findOne({ username });

--- a/css/style.css
+++ b/css/style.css
@@ -229,6 +229,12 @@ body {
   font-size: 14px;
 }
 
+.password-hint {
+  font-size: 12px;
+  color: #666;
+  margin-top: 4px;
+}
+
 .auth-link {
   margin-top: 10px;
   font-size: 14px;

--- a/js/login.js
+++ b/js/login.js
@@ -11,7 +11,10 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password })
     });
-
+    if (res.status === 429) {
+      alert('Too many login attempts. Please try again later.');
+      return;
+    }
     if (!res.ok) throw new Error('Login failed');
 
     const data = await res.json();
@@ -19,6 +22,6 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     window.location.href = 'index.html';
   } catch (err) {
     console.error('❌ Login error:', err.message);
-    alert('Login failed. Please check your credentials.');
+    alert(err.message || 'Login failed. Please check your credentials.');
   }
 });

--- a/js/register.js
+++ b/js/register.js
@@ -4,6 +4,19 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
   e.preventDefault();
   const username = document.getElementById('username').value.trim();
   const password = document.getElementById('password').value;
+  const confirmPassword = document.getElementById('confirm-password').value;
+
+  const passwordPattern = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,}$/;
+  if (!passwordPattern.test(password)) {
+    alert(
+      'Password must be at least 8 characters and include uppercase, lowercase, number and special character.'
+    );
+    return;
+  }
+  if (password !== confirmPassword) {
+    alert('Passwords do not match.');
+    return;
+  }
 
   try {
     const res = await fetch(`${API_BASE_URL}/auth/register`, {

--- a/register.html
+++ b/register.html
@@ -20,6 +20,11 @@
           <div class="form-group">
             <label for="password">Password</label>
             <input type="password" id="password" required />
+            <small class="password-hint">At least 8 characters with uppercase, lowercase, number and special character.</small>
+          </div>
+          <div class="form-group">
+            <label for="confirm-password">Confirm Password</label>
+            <input type="password" id="confirm-password" required />
           </div>
         </div>
         <button class="btn" type="submit">Register</button>


### PR DESCRIPTION
## Summary
- enforce strong password requirements on registration
- throttle repeated login attempts per IP
- add confirmation and guidance to registration form with client-side checks

## Testing
- `npm test`
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e1be45148323aaf6f1f84ea88d01