### PR TITLE
Expose API failure reasons to users

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -27,6 +27,7 @@ async function loadUsers() {
     document.getElementById('user-count-header').textContent = `Total Users: ${users.length}`;
   } catch (err) {
     console.error(err);
+    alert(err.message || 'Failed to load users');
   }
 }
 

--- a/js/bets.js
+++ b/js/bets.js
@@ -18,6 +18,7 @@ export async function fetchBets() {
   } catch (err) {
     console.error('❌ Error fetching bets:', err.message);
     bets = [];
+    alert(err.message || 'Failed to fetch bets');
   }
 }
 
@@ -51,6 +52,7 @@ export async function addBet(bet) {
     bets.push(savedBet);
   } catch (err) {
     console.error('❌ Error adding bet:', err.message);
+    alert(err.message || 'Failed to add bet');
   }
 }
 
@@ -64,6 +66,7 @@ export async function removeBet(betId) {
     bets = bets.filter(b => b._id !== betId);
   } catch (err) {
     console.error('❌ Error removing bet:', err.message);
+    alert(err.message || 'Failed to remove bet');
   }
 }
 
@@ -74,6 +77,7 @@ export async function clearBets() {
     await fetch(API_URL, { method: 'DELETE', headers: authHeaders() });
   } catch (err) {
     console.error('❌ Error clearing bets:', err.message);
+    alert(err.message || 'Failed to clear bets');
   }
 }
 
@@ -109,6 +113,7 @@ export async function settleBet(betId, newOutcome) {
     }
   } catch (err) {
     console.error('❌ Error settling bet:', err.message);
+    alert(err.message || 'Failed to update bet');
   }
 }
 

--- a/js/register.js
+++ b/js/register.js
@@ -32,6 +32,6 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
     window.location.href = 'index.html';
   } catch (err) {
     console.error('❌ Registration error:', err.message);
-    alert('Registration failed. Please try again.');
+    alert(err.message || 'Registration failed. Please try again.');
   }
 });

--- a/js/stats.js
+++ b/js/stats.js
@@ -13,8 +13,8 @@ async function fetchUserStats() {
     return await res.json();
   } catch (err) {
     console.error('❌ Error fetching user stats:', err.message);
+    alert(err.message || 'Failed to fetch user stats');
     return null;
-
   }
 }
 


### PR DESCRIPTION
## Summary
- alert users when fetching bets fails instead of silently clearing data
- propagate API failure messages for bet actions, registration, stats, and admin pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3e6934d208323849c44c230dd02f7