### PR TITLE
Sanitize user-generated text in betting views

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,5 +1,5 @@
 import { API_BASE_URL } from './config.js';
-import { decodeToken } from './utils.js';
+import { decodeToken, escapeHtml } from './utils.js';
 
 const API_URL = `${API_BASE_URL}/users`;
 
@@ -23,7 +23,7 @@ async function loadUsers() {
     if (!res.ok) throw new Error('Failed to fetch users');
     const users = await res.json();
     const list = document.getElementById('user-list');
-    list.innerHTML = users.map(u => `<li>${u.username}</li>`).join('');
+    list.innerHTML = users.map(u => `<li>${escapeHtml(u.username)}</li>`).join('');
     document.getElementById('user-count-header').textContent = `Total Users: ${users.length}`;
   } catch (err) {
     console.error(err);

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,4 +1,4 @@
-import { formatDate } from './utils.js';
+import { formatDate, escapeHtml } from './utils.js';
 
 let activeModal = null;
 let previousFocus = null;
@@ -72,10 +72,10 @@ export function showBetDetails(bet) {
   const body = document.getElementById('betDetailsBody');
   if (modal && body) {
     const details = [
-      { label: 'Outcome', value: bet.outcome, class: `status ${bet.outcome.toLowerCase()}` },
-      { label: 'Description', value: bet.description || '', class: '' },
-      { label: 'Bet Type', value: bet.betType, class: '' },
-      { label: 'Odds', value: bet.odds, class: parseFloat(bet.odds) > 0 ? 'positive' : parseFloat(bet.odds) < 0 ? 'negative' : '' },
+      { label: 'Outcome', value: escapeHtml(bet.outcome), class: `status ${bet.outcome.toLowerCase()}` },
+      { label: 'Description', value: escapeHtml(bet.description || ''), class: '' },
+      { label: 'Bet Type', value: escapeHtml(bet.betType), class: '' },
+      { label: 'Odds', value: escapeHtml(bet.odds), class: parseFloat(bet.odds) > 0 ? 'positive' : parseFloat(bet.odds) < 0 ? 'negative' : '' },
       { label: 'Stake', value: `$${parseFloat(bet.stake).toFixed(2)}`, class: '' },
       { label: 'Payout', value: `$${parseFloat(bet.payout).toFixed(2)}`, class: bet.payout > 0 ? 'positive' : '' },
       {
@@ -84,9 +84,9 @@ export function showBetDetails(bet) {
         class: bet.outcome === 'Pending' ? '' : bet.profitLoss > 0 ? 'positive' : bet.profitLoss < 0 ? 'negative' : ''
       },
       { label: 'Date', value: formatDate(bet.date), class: '' },
-      { label: 'Event', value: bet.event, class: '' },
-      { label: 'Sport', value: bet.sport, class: '' },
-      { label: 'Note', value: bet.note || '', class: '', fullWidth: true }
+      { label: 'Event', value: escapeHtml(bet.event), class: '' },
+      { label: 'Sport', value: escapeHtml(bet.sport), class: '' },
+      { label: 'Note', value: escapeHtml(bet.note || ''), class: '', fullWidth: true }
     ];
 
     body.innerHTML = '';

--- a/js/render.js
+++ b/js/render.js
@@ -1,6 +1,6 @@
 import { bets, removeBet as removeBetData, settleBet as settleBetData } from './bets.js';
 import { updateStats } from './stats.js';
-import { formatDate } from './utils.js';
+import { formatDate, escapeHtml } from './utils.js';
 import { showBetDetails } from './modal.js';
 
 export async function handleRemoveBet(id) {
@@ -53,30 +53,38 @@ export function renderBets() {
     const profitClass = bet.profitLoss > 0 ? 'positive' : bet.profitLoss < 0 ? 'negative' : '';
     const profitSymbol = bet.profitLoss > 0 ? '+' : '';
 
-      row.innerHTML = `
-        <td>${bet.outcome}</td>
-        <td class="event-cell">
-          <div class="event-content" title="${bet.event}" onclick="showFullText(${JSON.stringify(bet.event)})">
-            ${bet.event}
-          </div>
-        </td>
-        <td class="description-cell">
-          <div class="description-content" title="${bet.description || ''}" onclick="showFullText(${JSON.stringify(bet.description || '')})">
-            ${bet.description || ''}
-          </div>
-        </td>
-      <td>${bet.betType}</td>
-      <td>${bet.odds}</td>
+    const safeOutcome = escapeHtml(bet.outcome);
+    const safeEvent = escapeHtml(bet.event);
+    const safeDescription = escapeHtml(bet.description || '');
+    const safeBetType = escapeHtml(bet.betType);
+    const safeOdds = escapeHtml(bet.odds);
+    const safeSport = escapeHtml(bet.sport);
+    const safeNote = escapeHtml(bet.note || '');
+
+    row.innerHTML = `
+      <td>${safeOutcome}</td>
+      <td class="event-cell">
+        <div class="event-content" title="${safeEvent}" onclick="showFullText(${JSON.stringify(bet.event)})">
+          ${safeEvent}
+        </div>
+      </td>
+      <td class="description-cell">
+        <div class="description-content" title="${safeDescription}" onclick="showFullText(${JSON.stringify(bet.description || '')})">
+          ${safeDescription}
+        </div>
+      </td>
+      <td>${safeBetType}</td>
+      <td>${safeOdds}</td>
       <td>$${parseFloat(bet.stake).toFixed(2)}</td>
       <td>$${parseFloat(bet.payout).toFixed(2)}</td>
       <td class="${profitClass}">
         ${bet.outcome === 'Pending' ? '—' : profitSymbol + '$' + parseFloat(bet.profitLoss).toFixed(2)}
       </td>
-        <td>${formatDate(bet.date)}</td>
-      <td>${bet.sport}</td>
+      <td>${formatDate(bet.date)}</td>
+      <td>${safeSport}</td>
       <td class="note-cell">
-        <div class="note-content" title="${bet.note || ''}" onclick="showFullText(${JSON.stringify(bet.note || '')})">
-          ${bet.note || ''}
+        <div class="note-content" title="${safeNote}" onclick="showFullText(${JSON.stringify(bet.note || '')})">
+          ${safeNote}
         </div>
       </td>
     `;

--- a/js/utils.js
+++ b/js/utils.js
@@ -13,3 +13,12 @@ export function decodeToken(token) {
     return null;
   }
 }
+
+export function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Summary
- escape user-supplied strings before injecting into DOM
- sanitize bet table rows and details modal to prevent HTML injection
- guard admin user list against XSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3e7e8b818832384eec3a519970159