### PR TITLE
feat: add basic logger

### DIFF
--- a/betting-tracker-backend/scripts/addPendingBets.js
+++ b/betting-tracker-backend/scripts/addPendingBets.js
@@ -2,6 +2,7 @@ const path = require('path');
 require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
 const mongoose = require('mongoose');
 const Bet = require('../models/Bet');
+const logger = require('../utils/logger');
 
 const bets = [
   {
@@ -179,9 +180,9 @@ async function insertBets() {
   try {
     await mongoose.connect(process.env.MONGO_URI);
     const result = await Bet.insertMany(bets);
-    console.log(`${result.length} bets inserted`);
+    logger.info(`${result.length} bets inserted`);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   } finally {
     await mongoose.disconnect();
   }

--- a/betting-tracker-backend/scripts/updateUserStats.js
+++ b/betting-tracker-backend/scripts/updateUserStats.js
@@ -3,6 +3,7 @@ require('dotenv').config({ path: path.resolve(__dirname, '..', '.env') });
 const mongoose = require('mongoose');
 const User = require('../models/User');
 const { updateUserStats } = require('../utils/userStats');
+const logger = require('../utils/logger');
 
 async function run() {
   try {
@@ -10,10 +11,10 @@ async function run() {
     const users = await User.find();
     for (const user of users) {
       await updateUserStats(user._id);
-      console.log(`Updated stats for ${user.username}`);
+      logger.info(`Updated stats for ${user.username}`);
     }
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   } finally {
     await mongoose.disconnect();
   }

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const cors = require('cors');
 require('dotenv').config();
 const auth = require('./middleware/auth');
+const logger = require('./utils/logger');
 
 const app = express();
 const PORT = process.env.PORT || 5000;
@@ -45,7 +46,7 @@ app.use(cors(corsOptions));
 
 // Debug logging
 app.use((req, res, next) => {
-  console.log('Host:', req.headers.host, 'Origin:', req.headers.origin);
+  logger.debug('Host:', req.headers.host, 'Origin:', req.headers.origin);
   next();
 });
 
@@ -56,8 +57,8 @@ mongoose.connect(process.env.MONGO_URI, {
   useNewUrlParser: true,
   useUnifiedTopology: true
 })
-.then(() => console.log('✅ MongoDB connected'))
-.catch((err) => console.error('❌ MongoDB connection error:', err));
+.then(() => logger.info('MongoDB connected'))
+.catch((err) => logger.error('MongoDB connection error:', err));
 
 // Example route
 app.get('/', (req, res) => {
@@ -73,5 +74,5 @@ app.use('/api/users', auth, userRoutes);
 
 // Start server
 app.listen(PORT, () => {
-  console.log(`🚀 Server running on port ${PORT}`);
+  logger.info(`Server running on port ${PORT}`);
 });

--- a/betting-tracker-backend/utils/logger.js
+++ b/betting-tracker-backend/utils/logger.js
@@ -1,0 +1,15 @@
+const levels = ['error', 'warn', 'info', 'debug'];
+const level = levels.indexOf((process.env.LOG_LEVEL || 'info').toLowerCase());
+
+function shouldLog(lvl) {
+  return levels.indexOf(lvl) <= level;
+}
+
+const logger = {
+  error: (...args) => shouldLog('error') && console.error('[ERROR]', ...args),
+  warn: (...args) => shouldLog('warn') && console.warn('[WARN]', ...args),
+  info: (...args) => shouldLog('info') && console.info('[INFO]', ...args),
+  debug: (...args) => shouldLog('debug') && console.debug('[DEBUG]', ...args),
+};
+
+module.exports = logger;

--- a/scripts/assignUserToBets.js
+++ b/scripts/assignUserToBets.js
@@ -1,10 +1,11 @@
 import mongoose from 'mongoose';
 import connectDB from '../src/db.js';
 import Bet from '../src/models/Bet.js';
+import logger from '../src/utils/logger.js';
 
 const userId = process.argv[2] || process.env.USER_ID;
 if (!userId) {
-  console.error('Usage: node scripts/assignUserToBets.js <userId>');
+  logger.error('Usage: node scripts/assignUserToBets.js <userId>');
   process.exit(1);
 }
 
@@ -15,9 +16,9 @@ if (!userId) {
       { user: { $exists: false } },
       { $set: { user: userId } }
     );
-    console.log(`Updated ${result.modifiedCount} bets`);
+    logger.info(`Updated ${result.modifiedCount} bets`);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
   } finally {
     await mongoose.disconnect();
   }

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import Bet from '../models/Bet.js';
 import authorize from '../middleware/authorize.js';
+import logger from '../utils/logger.js';
 
 const router = Router();
 
@@ -22,6 +23,7 @@ router.get('/', async (req, res) => {
     const bets = await Bet.find({ user: req.user.id });
     res.json(bets);
   } catch (err) {
+    logger.error(err);
     res.status(500).json({ error: 'Failed to fetch bets' });
   }
 });
@@ -29,7 +31,7 @@ router.get('/', async (req, res) => {
 router.post('/', async (req, res) => {
   const validationError = validateBet(req.body);
   if (validationError) {
-    console.error('Validation error:', validationError);
+    logger.warn('Validation error:', validationError);
     return res.status(400).json({ error: validationError });
   }
   try {
@@ -37,7 +39,7 @@ router.post('/', async (req, res) => {
     await newBet.save();
     res.status(201).json(newBet);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(400).json({ error: err.message });
   }
 });
@@ -50,6 +52,7 @@ router.delete('/', authorize('admin'), async (req, res) => {
     await Bet.deleteMany({ user: req.user.id });
     res.json({ message: 'All bets deleted' });
   } catch (err) {
+    logger.error(err);
     res.status(500).json({ error: 'Failed to delete bets' });
   }
 });
@@ -57,7 +60,7 @@ router.delete('/', authorize('admin'), async (req, res) => {
 router.put('/:id', async (req, res) => {
   const validationError = validateBet(req.body);
   if (validationError) {
-    console.error('Validation error:', validationError);
+    logger.warn('Validation error:', validationError);
     return res.status(400).json({ error: validationError });
   }
   try {
@@ -68,7 +71,7 @@ router.put('/:id', async (req, res) => {
     );
     res.json(updatedBet);
   } catch (err) {
-    console.error(err);
+    logger.error(err);
     res.status(400).json({ error: err.message });
   }
 });

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,13 @@
+const levels = ['error', 'warn', 'info', 'debug'];
+const level = levels.indexOf((process.env.LOG_LEVEL || 'info').toLowerCase());
+
+function shouldLog(lvl) {
+  return levels.indexOf(lvl) <= level;
+}
+
+export default {
+  error: (...args) => shouldLog('error') && console.error('[ERROR]', ...args),
+  warn: (...args) => shouldLog('warn') && console.warn('[WARN]', ...args),
+  info: (...args) => shouldLog('info') && console.info('[INFO]', ...args),
+  debug: (...args) => shouldLog('debug') && console.debug('[DEBUG]', ...args),
+};


### PR DESCRIPTION
## Summary
- add simple logger utility with log levels
- replace console.log usage in backend server and scripts
- route handlers now log warnings and errors via logger

## Testing
- `npm test`
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f3e4928c8323a12fc61824bed215