### PR TITLE
Add empty state for bets table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -352,6 +352,13 @@ tr:hover {
   font-weight: bold;
 }
 
+.empty-state td {
+  text-align: center;
+  padding: 20px;
+  color: #7f8c8d;
+  font-style: italic;
+}
+
 .download-section {
   padding: 20px;
   text-align: center;

--- a/js/render.js
+++ b/js/render.js
@@ -45,6 +45,14 @@ export function renderBets() {
     return 0;
   });
 
+  if (sorted.length === 0) {
+    const emptyRow = document.createElement('tr');
+    emptyRow.className = 'empty-state';
+    emptyRow.innerHTML = `<td colspan="11">No bets yet. Add your first bet to start tracking!</td>`;
+    tbody.appendChild(emptyRow);
+    return;
+  }
+
   sorted.forEach(bet => {
     const row = document.createElement('tr');
     row.className = bet.outcome.toLowerCase();


### PR DESCRIPTION
## Summary
- render a helpful message in the bets table when no bets exist
- style empty state row to match app aesthetics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3fd637ed08323b8af43653352ce42