### PR TITLE
Fix learn-more link and relax bet reset permissions

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -5,6 +5,7 @@ function updateAuthUI() {
   const logoutBtn = document.getElementById('logout-btn');
   const addBetBtn = document.getElementById('add-bet-btn');
   const signInBtn = document.getElementById('sign-in-btn');
+  const usernameEl = document.getElementById('username-display');
 
   const token = localStorage.getItem('token');
   const isLoggedIn = Boolean(token);
@@ -23,10 +24,17 @@ function updateAuthUI() {
         { once: true }
       );
     }
+    if (usernameEl) {
+      try {
+        const { username } = JSON.parse(atob(token.split('.')[1]));
+        usernameEl.textContent = `Logged in as ${username}`;
+      } catch {}
+    }
     if (addBetBtn) addBetBtn.style.display = 'inline-block';
     if (signInBtn) signInBtn.style.display = 'none';
   } else {
     if (logoutBtn) logoutBtn.style.display = 'none';
+    if (usernameEl) usernameEl.textContent = '';
     if (addBetBtn) addBetBtn.style.display = 'none';
     if (signInBtn) {
       signInBtn.style.display = 'inline-block';

--- a/login.html
+++ b/login.html
@@ -28,6 +28,10 @@
     </div>
   </div>
   <script src="js/loadShared.js"></script>
+  <script type="module">
+    import { showLearnMore } from './js/modal.js';
+    window.showLearnMore = showLearnMore;
+  </script>
   <script type="module" src="js/login.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -33,6 +33,10 @@
     </div>
   </div>
   <script src="js/loadShared.js"></script>
+  <script type="module">
+    import { showLearnMore } from './js/modal.js';
+    window.showLearnMore = showLearnMore;
+  </script>
   <script type="module" src="js/register.js"></script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -13,16 +13,17 @@
 
       <div class="controls">
         <h2>Settings</h2>
-        <div class="auth-controls">
-          <h3>Account</h3>
-          <a href="login.html" class="btn" id="login-btn">Log In</a>
-          <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
-          <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
-        </div>
         <div class="data-controls">
           <h3>Data</h3>
           <button class="btn" id="export-bets-btn">Export Bets to CSV</button>
           <button class="btn btn-danger" id="reset-bets-btn">Clear All Bets</button>
+        </div>
+        <div class="auth-controls">
+          <h3>Account</h3>
+          <p id="username-display"></p>
+          <a href="login.html" class="btn" id="login-btn">Log In</a>
+          <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
+          <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
         </div>
       </div>
     </div>

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import Bet from '../models/Bet.js';
-import authorize from '../middleware/authorize.js';
 import logger from '../utils/logger.js';
 
 const router = Router();
@@ -44,11 +43,8 @@ router.post('/', async (req, res) => {
   }
 });
 
-router.delete('/', authorize('admin'), async (req, res) => {
+router.delete('/', async (req, res) => {
   try {
-    if (req.user.role !== 'admin') {
-      return res.status(403).json({ error: 'Access denied' });
-    }
     await Bet.deleteMany({ user: req.user.id });
     res.json({ message: 'All bets deleted' });
   } catch (err) {


### PR DESCRIPTION
## Summary
- make Learn More link work on auth pages
- allow all users to clear their bets
- show username on Settings and move Data section above Account

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a49307d23c8323b3d2b8f2cc14d530