### PR TITLE
Enable universal bet clearing and improve settings UX

### DIFF
--- a/js/login.js
+++ b/js/login.js
@@ -1,4 +1,9 @@
 import { API_BASE_URL } from './config.js';
+import { showLearnMore, closeModal } from './modal.js';
+
+// Ensure shared header links work
+window.showLearnMore = showLearnMore;
+window.closeModal = closeModal;
 
 document.getElementById('login-form').addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/js/register.js
+++ b/js/register.js
@@ -1,4 +1,9 @@
 import { API_BASE_URL } from './config.js';
+import { showLearnMore, closeModal } from './modal.js';
+
+// Ensure shared header links work
+window.showLearnMore = showLearnMore;
+window.closeModal = closeModal;
 
 document.getElementById('register-form').addEventListener('submit', async (e) => {
   e.preventDefault();

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,7 @@
 import { clearBets, exportToCSV } from './bets.js';
 import { renderBets } from './render.js';
 import { updateStats } from './stats.js';
+import { decodeToken } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const resetBtn = document.getElementById('reset-bets-btn');
@@ -17,5 +18,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const exportBtn = document.getElementById('export-bets-btn');
   if (exportBtn) {
     exportBtn.addEventListener('click', exportToCSV);
+  }
+
+  const usernameDisplay = document.getElementById('username-display');
+  const token = localStorage.getItem('token');
+  if (usernameDisplay && token) {
+    const user = decodeToken(token);
+    if (user?.username) {
+      usernameDisplay.textContent = `Logged in as ${user.username}`;
+      usernameDisplay.style.display = 'block';
+    }
   }
 });

--- a/settings.html
+++ b/settings.html
@@ -13,16 +13,17 @@
 
       <div class="controls">
         <h2>Settings</h2>
-        <div class="auth-controls">
-          <h3>Account</h3>
-          <a href="login.html" class="btn" id="login-btn">Log In</a>
-          <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
-          <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
-        </div>
         <div class="data-controls">
           <h3>Data</h3>
           <button class="btn" id="export-bets-btn">Export Bets to CSV</button>
           <button class="btn btn-danger" id="reset-bets-btn">Clear All Bets</button>
+        </div>
+        <div class="auth-controls">
+          <h3>Account</h3>
+          <p id="username-display" style="display: none;"></p>
+          <a href="login.html" class="btn" id="login-btn">Log In</a>
+          <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
+          <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
         </div>
       </div>
     </div>

--- a/src/routes/bets.js
+++ b/src/routes/bets.js
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import Bet from '../models/Bet.js';
-import authorize from '../middleware/authorize.js';
 import logger from '../utils/logger.js';
 
 const router = Router();
@@ -44,11 +43,8 @@ router.post('/', async (req, res) => {
   }
 });
 
-router.delete('/', authorize('admin'), async (req, res) => {
+router.delete('/', async (req, res) => {
   try {
-    if (req.user.role !== 'admin') {
-      return res.status(403).json({ error: 'Access denied' });
-    }
     await Bet.deleteMany({ user: req.user.id });
     res.json({ message: 'All bets deleted' });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Fix Learn More link on auth pages by exposing modal handlers globally.
- Allow any authenticated user to clear their own bets via DELETE /bets.
- Reorder Settings page and show logged-in username in Account section.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a027af7c8323a15d9fefea287320