### PR TITLE
Allow users to delete their own bets without admin role

### DIFF
--- a/betting-tracker-backend/routes/bets.js
+++ b/betting-tracker-backend/routes/bets.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
 const Bet = require('../models/Bet');
-const authorize = require('../middleware/authorize');
 const { updateUserStats } = require('../utils/userStats');
 
 // Get all bets for the authenticated user
@@ -22,8 +21,8 @@ router.post('/', async (req, res) => {
   }
 });
 
-// Delete all bets for the authenticated user (admin only)
-router.delete('/', authorize('admin'), async (req, res) => {
+// Delete all bets for the authenticated user
+router.delete('/', async (req, res) => {
   await Bet.deleteMany({ user: req.user.id });
   await updateUserStats(req.user.id);
   res.json({ message: 'All bets deleted' });


### PR DESCRIPTION
## Summary
- Remove admin-only authorization from bulk bet deletion
- Clean up unused middleware import

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5fd1c3d648323b78ce829d14bf3c8