### PR TITLE
Remove Clear All Bets feature

### DIFF
--- a/betting-tracker-backend/routes/bets.js
+++ b/betting-tracker-backend/routes/bets.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
 const Bet = require('../models/Bet');
-const authorize = require('../middleware/authorize');
 const { updateUserStats } = require('../utils/userStats');
 
 // Get all bets for the authenticated user
@@ -20,13 +19,6 @@ router.post('/', async (req, res) => {
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
-});
-
-// Delete all bets for the authenticated user (admin only)
-router.delete('/', authorize('admin'), async (req, res) => {
-  await Bet.deleteMany({ user: req.user.id });
-  await updateUserStats(req.user.id);
-  res.json({ message: 'All bets deleted' });
 });
 
 // Update a bet for the authenticated user

--- a/js/bets.js
+++ b/js/bets.js
@@ -70,17 +70,6 @@ export async function removeBet(betId) {
   }
 }
 
-/** Clear all bets */
-export async function clearBets() {
-  bets = [];
-  try {
-    await fetch(API_URL, { method: 'DELETE', headers: authHeaders() });
-  } catch (err) {
-    console.error('❌ Error clearing bets:', err.message);
-    alert(err.message || 'Failed to clear bets');
-  }
-}
-
 /** Settle a bet by updating its outcome and recalculating */
 export async function settleBet(betId, newOutcome) {
   const bet = bets.find(b => b._id === betId);

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,20 +1,7 @@
-import { clearBets, exportToCSV } from './bets.js';
-import { renderBets } from './render.js';
-import { updateStats } from './stats.js';
+import { exportToCSV } from './bets.js';
 import { decodeToken } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const resetBtn = document.getElementById('reset-bets-btn');
-  if (resetBtn) {
-    resetBtn.addEventListener('click', async () => {
-      if (!confirm('Are you sure you want to clear all bets?')) return;
-      await clearBets();
-      renderBets();
-      await updateStats();
-      alert('All bets have been cleared.');
-    });
-  }
-
   const exportBtn = document.getElementById('export-bets-btn');
   if (exportBtn) {
     exportBtn.addEventListener('click', exportToCSV);

--- a/settings.html
+++ b/settings.html
@@ -16,7 +16,6 @@
         <div class="data-controls">
           <h3>Data</h3>
           <button class="btn" id="export-bets-btn">Export Bets to CSV</button>
-          <button class="btn btn-danger" id="reset-bets-btn">Clear All Bets</button>
         </div>
         <div class="auth-controls">
           <h3>Account</h3>


### PR DESCRIPTION
## Summary
- remove bulk bet deletion endpoint from backend
- drop Clear All Bets controls and logic from settings page
- excise unused clearBets helper

## Testing
- `npm test`
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a609bb56dc83238a706884ca7a0e13