### PR TITLE
feat: allow clearing betting history

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -267,6 +267,13 @@ body {
   background: #c0392b;
 }
 
+.danger-link {
+  color: #e74c3c;
+  cursor: pointer;
+  text-decoration: underline;
+  margin-top: 10px;
+}
+
 .table-container {
   overflow-x: auto;
   max-height: 500px;

--- a/js/bets.js
+++ b/js/bets.js
@@ -70,6 +70,20 @@ export async function removeBet(betId) {
   }
 }
 
+/** Remove all bets for the current user */
+export async function clearBets() {
+  try {
+    await fetch(API_URL, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    });
+    bets = [];
+  } catch (err) {
+    console.error('❌ Error clearing bets:', err.message);
+    alert(err.message || 'Failed to clear bets');
+  }
+}
+
 /** Settle a bet by updating its outcome and recalculating */
 export async function settleBet(betId, newOutcome) {
   const bet = bets.find(b => b._id === betId);

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,10 +1,21 @@
-import { exportToCSV } from './bets.js';
+import { exportToCSV, clearBets } from './bets.js';
 import { decodeToken } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const exportBtn = document.getElementById('export-bets-btn');
   if (exportBtn) {
     exportBtn.addEventListener('click', exportToCSV);
+  }
+
+  const clearLink = document.getElementById('clear-bets-link');
+  if (clearLink) {
+    clearLink.addEventListener('click', async (e) => {
+      e.preventDefault();
+      if (confirm('Are you sure you want to clear your betting history?')) {
+        await clearBets();
+        alert('Betting history cleared');
+      }
+    });
   }
 
   const usernameDisplay = document.getElementById('username-display');
@@ -15,5 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
       usernameDisplay.textContent = `Logged in as ${user.username}`;
       usernameDisplay.style.display = 'block';
     }
+  }
+
+  if (clearLink && token) {
+    clearLink.style.display = 'block';
   }
 });

--- a/settings.html
+++ b/settings.html
@@ -16,6 +16,7 @@
         <div class="data-controls">
           <h3>Data</h3>
           <button class="btn" id="export-bets-btn">Export Bets to CSV</button>
+          <p id="clear-bets-link" class="danger-link" style="display: none;">Clear betting history</p>
         </div>
         <div class="auth-controls">
           <h3>Account</h3>


### PR DESCRIPTION
## Summary
- add clear betting history option in settings
- allow users to delete all bets
- style the new link as a danger action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a62877d65083239d9aa777e5303788