### PR TITLE
Fix Learn More modal on login and sign up pages

### DIFF
--- a/login.html
+++ b/login.html
@@ -27,6 +27,9 @@
       <p class="auth-link">Don't have an account? <a href="register.html">Sign up</a></p>
     </div>
   </div>
+
+  <!-- MODAL -->
+  <div id="include-modal"></div>
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/login.js"></script>
 </body>

--- a/register.html
+++ b/register.html
@@ -32,6 +32,9 @@
       <p class="auth-link">Already have an account? <a href="login.html">Log in</a></p>
     </div>
   </div>
+  
+  <!-- MODAL -->
+  <div id="include-modal"></div>
   <script src="js/loadShared.js"></script>
   <script type="module" src="js/register.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Ensure auth pages load shared modal so "Learn More" link opens properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6339c4e5c83239941dac5dde0c450