### PR TITLE
Remove boxed layout styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,17 +2,13 @@
 body {
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   margin: 0;
-  padding: 20px; 
-  background-color: #f5f5f5;
+  padding: 0;
+  background-color: white;
 }
 
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  background: white;
-  border-radius: 8px;
-  box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-  overflow: hidden;
 }
 
   .header {


### PR DESCRIPTION
## Summary
- Remove body padding and use white background
- Strip container background, radius, and shadow to eliminate boxed layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa290f29488323874cdc5c615a8b79