### PR TITLE
feat: cache mongoose connection

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,15 +1,31 @@
 import mongoose from 'mongoose';
 
-let cached = global._mongoose;
-if (!cached) cached = global._mongoose = { conn: null, promise: null };
+// Reuse the same Mongoose connection across hot reloads or serverless
+// function invocations.  The `globalThis` scope survives for the lifetime
+// of the runtime so we store the connection state there.  Each cold start
+// will initialise this object once and subsequent invocations will reuse
+// the existing connection instead of creating a new one.
+let cached = globalThis.mongooseConn;
+if (!cached) {
+  cached = globalThis.mongooseConn = { conn: null, promise: null };
+}
+
+const { MONGO_URI } = process.env;
+if (!MONGO_URI) {
+  throw new Error('Missing MONGO_URI');
+}
 
 export default async function connectDB() {
-  if (cached.conn) return cached.conn;
-  if (!cached.promise) {
-    const uri = process.env.MONGO_URI;
-    if (!uri) throw new Error('Missing MONGO_URI');
-    cached.promise = mongoose.connect(uri, { bufferCommands: false }).then((m) => m);
+  if (cached.conn) {
+    return cached.conn;
   }
+
+  if (!cached.promise) {
+    cached.promise = mongoose
+      .connect(MONGO_URI, { bufferCommands: false })
+      .then(m => m);
+  }
+
   cached.conn = await cached.promise;
   return cached.conn;
 }


### PR DESCRIPTION
## Summary
- cache Mongoose connection in a global variable so serverless invocations reuse it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acb544d984832388d9e95670018c13