### PR TITLE
Use HttpOnly cookies for authentication

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -12,7 +12,7 @@
     <h2 id="user-count-header">Total Users: 0</h2>
     <ul id="user-list"></ul>
   </div>
-  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/loadShared.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>
 </html>

--- a/betting-tracker-backend/middleware/auth.js
+++ b/betting-tracker-backend/middleware/auth.js
@@ -2,7 +2,7 @@ const jwt = require('jsonwebtoken');
 
 module.exports = function (req, res, next) {
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  const token = req.cookies?.token || (authHeader && authHeader.split(' ')[1]);
   if (!token) {
     return res.status(401).json({ error: 'No token provided' });
   }

--- a/betting-tracker-backend/package.json
+++ b/betting-tracker-backend/package.json
@@ -17,7 +17,8 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.17.0"
+    "mongoose": "^8.17.0",
+    "cookie-parser": "^1.4.6"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/betting-tracker-backend/routes/auth.js
+++ b/betting-tracker-backend/routes/auth.js
@@ -53,7 +53,15 @@ router.post('/register', async (req, res) => {
       process.env.JWT_SECRET,
       { expiresIn: '7d' }
     );
-    res.status(201).json({ token });
+    res
+      .cookie('token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+      })
+      .status(201)
+      .json({ message: 'Registered' });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -75,10 +83,27 @@ router.post('/login', loginRateLimiter, async (req, res) => {
       process.env.JWT_SECRET,
       { expiresIn: '7d' }
     );
-    res.json({ token });
+    res
+      .cookie('token', token, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'strict',
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+      })
+      .json({ message: 'Logged in' });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
+});
+
+router.post('/logout', (req, res) => {
+  res
+    .clearCookie('token', {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'strict',
+    })
+    .json({ message: 'Logged out' });
 });
 
 module.exports = router;

--- a/betting-tracker-backend/routes/users.js
+++ b/betting-tracker-backend/routes/users.js
@@ -19,7 +19,7 @@ router.get('/', authorize('admin'), async (req, res) => {
 router.get('/me', async (req, res) => {
   try {
     await updateUserStats(req.user.id);
-    const user = await User.findById(req.user.id).select('username stats');
+    const user = await User.findById(req.user.id).select('username stats role');
     res.json(user);
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
+const cookieParser = require('cookie-parser');
 require('dotenv').config();
 const auth = require('./middleware/auth');
 const logger = require('./utils/logger');
@@ -43,6 +44,7 @@ const corsOptions = {
 };
 
 app.use(cors(corsOptions));
+app.use(cookieParser());
 
 // Debug logging
 app.use((req, res, next) => {

--- a/index.html
+++ b/index.html
@@ -117,8 +117,8 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
-  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
-  <script src="js/auth.js"></script>
+  <script type="module" src="js/auth.js"></script>
 </body>
 </html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,25 +1,22 @@
 import { API_BASE_URL } from './config.js';
-import { decodeToken, escapeHtml } from './utils.js';
+import { escapeHtml } from './utils.js';
 
 const API_URL = `${API_BASE_URL}/users`;
 
 async function loadUsers() {
-  const token = localStorage.getItem('token');
-  if (!token) {
-    window.location.href = 'login.html';
-    return;
-  }
-
-  const user = decodeToken(token);
-  if (!user || user.role !== 'admin') {
-    window.location.href = 'index.html';
-    return;
-  }
-
   try {
-    const res = await fetch(API_URL, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const meRes = await fetch(`${API_BASE_URL}/users/me`, { credentials: 'include' });
+    if (!meRes.ok) {
+      window.location.href = 'login.html';
+      return;
+    }
+    const currentUser = await meRes.json();
+    if (currentUser.role !== 'admin') {
+      window.location.href = 'index.html';
+      return;
+    }
+
+    const res = await fetch(API_URL, { credentials: 'include' });
     if (!res.ok) throw new Error('Failed to fetch users');
     const users = await res.json();
     const list = document.getElementById('user-list');

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,7 @@ import { initForm, handleAddBet, saveFormData } from './form.js';
 import { renderBets, handleRemoveBet, handleSettleBet, showTableLoading } from './render.js';
 import { updateStats } from './stats.js';
 import { showFullText, closeModal, showLearnMore } from './modal.js';
+import { API_BASE_URL } from './config.js';
 
 // Always make core functions globally available for buttons
 window.addBet = handleAddBet;
@@ -24,18 +25,25 @@ window.saveFormData = saveFormData;
 initForm();
 
 // Wait for shared HTML components before loading bets
-  window.addEventListener('shared:loaded', async () => {
-    const isDemoMode = new URLSearchParams(window.location.search).get('demo');
-    const token = localStorage.getItem('token');
+window.addEventListener('shared:loaded', async () => {
+  const isDemoMode = new URLSearchParams(window.location.search).get('demo');
 
-    showTableLoading();
+  showTableLoading();
 
-    if (isDemoMode || !token) {
-      loadDemoBets();
-    } else {
-      await fetchBets();
-    }
+  let loggedIn = false;
+  if (!isDemoMode) {
+    try {
+      const res = await fetch(`${API_BASE_URL}/users/me`, { credentials: 'include' });
+      loggedIn = res.ok;
+    } catch {}
+  }
 
-    renderBets();
-    await updateStats();
-  });
+  if (isDemoMode || !loggedIn) {
+    loadDemoBets();
+  } else {
+    await fetchBets();
+  }
+
+  renderBets();
+  await updateStats();
+});

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,13 +1,17 @@
-// Simple auth state handling for UI
-function updateAuthUI() {
+import { API_BASE_URL } from './config.js';
+
+async function updateAuthUI() {
   const loginBtn = document.getElementById('login-btn');
   const signupBtn = document.getElementById('signup-btn');
   const logoutBtn = document.getElementById('logout-btn');
   const addBetBtn = document.getElementById('add-bet-btn');
   const signInBtn = document.getElementById('sign-in-btn');
 
-  const token = localStorage.getItem('token');
-  const isLoggedIn = Boolean(token);
+  let isLoggedIn = false;
+  try {
+    const res = await fetch(`${API_BASE_URL}/users/me`, { credentials: 'include' });
+    isLoggedIn = res.ok;
+  } catch {}
 
   if (isLoggedIn) {
     if (loginBtn) loginBtn.style.display = 'none';
@@ -16,8 +20,8 @@ function updateAuthUI() {
       logoutBtn.style.display = 'inline-block';
       logoutBtn.addEventListener(
         'click',
-        () => {
-          localStorage.removeItem('token');
+        async () => {
+          await fetch(`${API_BASE_URL}/auth/logout`, { method: 'POST', credentials: 'include' });
           window.location.href = '/index.html';
         },
         { once: true }
@@ -30,11 +34,15 @@ function updateAuthUI() {
     if (addBetBtn) addBetBtn.style.display = 'none';
     if (signInBtn) {
       signInBtn.style.display = 'inline-block';
-      signInBtn.addEventListener('click', () => {
-        if (typeof window.saveFormData === 'function') {
-          window.saveFormData();
-        }
-      }, { once: true });
+      signInBtn.addEventListener(
+        'click',
+        () => {
+          if (typeof window.saveFormData === 'function') {
+            window.saveFormData();
+          }
+        },
+        { once: true }
+      );
     }
   }
 }

--- a/js/bets.js
+++ b/js/bets.js
@@ -4,15 +4,10 @@ export let bets = [];
 
 const API_URL = `${API_BASE_URL}/bets`;
 
-function authHeaders(extra = {}) {
-  const token = localStorage.getItem('token');
-  return token ? { ...extra, Authorization: `Bearer ${token}` } : { ...extra };
-}
-
 /** Fetch all bets from the backend */
 export async function fetchBets() {
   try {
-    const res = await fetch(API_URL, { headers: authHeaders() });
+    const res = await fetch(API_URL, { credentials: 'include' });
     if (!res.ok) throw new Error('Failed to fetch bets');
     bets = await res.json();
   } catch (err) {
@@ -45,7 +40,8 @@ export async function addBet(bet) {
   try {
     const res = await fetch(API_URL, {
       method: 'POST',
-      headers: authHeaders({ 'Content-Type': 'application/json' }),
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(bet),
     });
     const savedBet = await res.json();
@@ -61,7 +57,7 @@ export async function removeBet(betId) {
   try {
     await fetch(`${API_URL}/${betId}`, {
       method: 'DELETE',
-      headers: authHeaders(),
+      credentials: 'include',
     });
     bets = bets.filter(b => b._id !== betId);
   } catch (err) {
@@ -75,7 +71,7 @@ export async function clearBets() {
   try {
     await fetch(API_URL, {
       method: 'DELETE',
-      headers: authHeaders(),
+      credentials: 'include',
     });
     bets = [];
   } catch (err) {
@@ -105,7 +101,8 @@ export async function settleBet(betId, newOutcome) {
   try {
     const res = await fetch(`${API_URL}/${betId}`, {
       method: 'PUT',
-      headers: authHeaders({ 'Content-Type': 'application/json' }),
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify(bet),
     });
 

--- a/js/config.js
+++ b/js/config.js
@@ -1,3 +1,6 @@
 const defaultApiBase = 'https://betting-tracker-backend.vercel.app/api';
 export const API_BASE_URL =
   (typeof process !== 'undefined' && process.env?.API_BASE_URL) || defaultApiBase;
+if (typeof window !== 'undefined') {
+  window.API_BASE_URL = API_BASE_URL;
+}

--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -1,8 +1,10 @@
-function getUser() {
-  const token = localStorage.getItem('token');
-  if (!token) return null;
+import { API_BASE_URL } from './config.js';
+
+async function getUser() {
   try {
-    return JSON.parse(atob(token.split('.')[1]));
+    const res = await fetch(`${API_BASE_URL}/users/me`, { credentials: 'include' });
+    if (!res.ok) return null;
+    return await res.json();
   } catch {
     return null;
   }
@@ -37,7 +39,7 @@ async function loadSharedComponents() {
       const html = await res.text();
       target.innerHTML = html;
 
-      const user = getUser();
+      const user = await getUser();
 
       if (key === 'header') {
         const adminLink = target.querySelector('a[href="admin.html"]');

--- a/js/login.js
+++ b/js/login.js
@@ -14,6 +14,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     const res = await fetch(`${API_BASE_URL}/auth/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({ username, password })
     });
     if (res.status === 429) {
@@ -22,8 +23,7 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     }
     if (!res.ok) throw new Error('Login failed');
 
-    const data = await res.json();
-    localStorage.setItem('token', data.token);
+    await res.json();
     window.location.href = 'index.html';
   } catch (err) {
     console.error('❌ Login error:', err.message);

--- a/js/register.js
+++ b/js/register.js
@@ -27,13 +27,13 @@ document.getElementById('register-form').addEventListener('submit', async (e) =>
     const res = await fetch(`${API_BASE_URL}/auth/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
       body: JSON.stringify({ username, password })
     });
 
     if (!res.ok) throw new Error('Registration failed');
 
-    const data = await res.json();
-    localStorage.setItem('token', data.token);
+    await res.json();
     window.location.href = 'index.html';
   } catch (err) {
     console.error('❌ Registration error:', err.message);

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,7 +1,7 @@
 import { exportToCSV, clearBets } from './bets.js';
-import { decodeToken } from './utils.js';
+import { API_BASE_URL } from './config.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const exportBtn = document.getElementById('export-bets-btn');
   if (exportBtn) {
     exportBtn.addEventListener('click', exportToCSV);
@@ -19,16 +19,17 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const usernameDisplay = document.getElementById('username-display');
-  const token = localStorage.getItem('token');
-  if (usernameDisplay && token) {
-    const user = decodeToken(token);
-    if (user?.username) {
-      usernameDisplay.textContent = `Logged in as ${user.username}`;
-      usernameDisplay.style.display = 'block';
+  try {
+    const res = await fetch(`${API_BASE_URL}/users/me`, { credentials: 'include' });
+    if (res.ok) {
+      const user = await res.json();
+      if (usernameDisplay && user?.username) {
+        usernameDisplay.textContent = `Logged in as ${user.username}`;
+        usernameDisplay.style.display = 'block';
+      }
+      if (clearLink) {
+        clearLink.style.display = 'block';
+      }
     }
-  }
-
-  if (clearLink && token) {
-    clearLink.style.display = 'block';
-  }
+  } catch {}
 });

--- a/js/stats.js
+++ b/js/stats.js
@@ -3,11 +3,9 @@ import { API_BASE_URL } from './config.js';
 import { bets } from './bets.js';
 
 async function fetchUserStats() {
-  const token = localStorage.getItem('token');
-  if (!token) return null;
   try {
     const res = await fetch(`${API_BASE_URL}/users/me`, {
-      headers: { Authorization: `Bearer ${token}` }
+      credentials: 'include'
     });
     if (!res.ok) throw new Error('Failed to fetch stats');
     return await res.json();
@@ -63,15 +61,14 @@ function calculateDemoStats() {
 
 export async function updateStats() {
   const isDemoMode = new URLSearchParams(window.location.search).get('demo');
-  const token = localStorage.getItem('token');
   const el = id => document.getElementById(id);
 
   let stats = null;
-  if (!token || isDemoMode) {
+  if (isDemoMode) {
     stats = calculateDemoStats();
   } else {
     const user = await fetchUserStats();
-    stats = user?.stats;
+    stats = user?.stats || calculateDemoStats();
   }
 
   if (stats) {

--- a/login.html
+++ b/login.html
@@ -30,7 +30,7 @@
 
   <!-- MODAL -->
   <div id="include-modal"></div>
-  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/loadShared.js"></script>
   <script type="module" src="js/login.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -65,7 +65,7 @@
   <!-- MODAL -->
   <div id="include-modal"></div>
 
-  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/loadShared.js"></script>
   <script type="module" src="js/app.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -35,7 +35,7 @@
   
   <!-- MODAL -->
   <div id="include-modal"></div>
-  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/loadShared.js"></script>
   <script type="module" src="js/register.js"></script>
 </body>
 </html>

--- a/settings.html
+++ b/settings.html
@@ -28,10 +28,10 @@
       </div>
     </div>
 
-    <script src="js/loadShared.js"></script>
+    <script type="module" src="js/loadShared.js"></script>
     <script type="module" src="js/app.js"></script>
     <script type="module" src="js/settings.js"></script>
-    <script src="js/auth.js"></script>
+    <script type="module" src="js/auth.js"></script>
   <script>
     window.addEventListener('shared:loaded', () => {
       const title = document.getElementById('page-title');

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -2,7 +2,7 @@ import jwt from 'jsonwebtoken';
 
 export default function (req, res, next) {
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  const token = req.cookies?.token || (authHeader && authHeader.split(' ')[1]);
   if (!token) {
     return res.status(401).json({ error: 'No token provided' });
   }

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -13,4 +13,13 @@ router.get('/', authorize('admin'), async (req, res) => {
   }
 });
 
+router.get('/me', async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select('username role');
+    res.json(user);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- Store JWTs in secure HttpOnly cookies and add logout route
- Read tokens from cookies in auth middleware
- Remove localStorage usage on the frontend and send credentials with requests

## Testing
- `npm test`
- `cd betting-tracker-backend && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68acbeab7d788323b3a0c6c5479c5e8c