### PR TITLE
Secure auth cookies and include credentials in frontend fetch

### DIFF
--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -34,7 +34,7 @@ async function loadSharedComponents() {
     if (!target) return;
 
     try {
-      const res = await fetch(path);
+      const res = await fetch(path, { credentials: 'include' });
       if (!res.ok) throw new Error(`${path} not found`);
       const html = await res.text();
       target.innerHTML = html;
@@ -58,7 +58,7 @@ async function loadSharedComponents() {
 
       // Profile-specific behavior
       if (key === 'header' && window.location.pathname.includes('profile.html')) {
-        const profileRes = await fetch('shared/profile-header.html');
+        const profileRes = await fetch('shared/profile-header.html', { credentials: 'include' });
         if (!profileRes.ok) throw new Error('shared/profile-header.html not found');
         const profileHTML = await profileRes.text();
 

--- a/src/app.js
+++ b/src/app.js
@@ -24,7 +24,7 @@ const envAllowed = (process.env.ALLOWED_ORIGINS || '')
   .filter(Boolean);
 
 const allowedOrigins = new Set([
-  'https://betting-tracker-nine.vercel.app/', // TODO: replace with your actual frontend domain
+  'https://betting-tracker-nine.vercel.app', // frontend domain
   'http://localhost:5173',            // Vite dev (change/remove if not used)
   'http://localhost:3000',            // Next.js/other local dev
   ...envAllowed,

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -18,12 +18,16 @@ router.post('/register', async (req, res) => {
     const hashedPassword = await bcrypt.hash(password, 10);
     user = new User({ username, password: hashedPassword, role: role || 'user' });
     await user.save();
-    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET, { expiresIn: '7d' });
+    const token = jwt.sign(
+      { id: user._id, username: user.username, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
     res
       .cookie('token', token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        secure: true, // required when sameSite is 'None'
+        sameSite: 'None',
         maxAge: 7 * 24 * 60 * 60 * 1000,
       })
       .status(201)
@@ -44,12 +48,16 @@ router.post('/login', async (req, res) => {
     if (!isMatch) {
       return res.status(400).json({ error: 'Invalid credentials' });
     }
-    const token = jwt.sign({ id: user._id, username: user.username, role: user.role }, process.env.JWT_SECRET, { expiresIn: '7d' });
+    const token = jwt.sign(
+      { id: user._id, username: user.username, role: user.role },
+      process.env.JWT_SECRET,
+      { expiresIn: '7d' }
+    );
     res
       .cookie('token', token, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: 'strict',
+        secure: true, // required when sameSite is 'None'
+        sameSite: 'None',
         maxAge: 7 * 24 * 60 * 60 * 1000,
       })
       .json({ message: 'Logged in' });
@@ -62,8 +70,8 @@ router.post('/logout', (req, res) => {
   res
     .clearCookie('token', {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'strict',
+      secure: true, // required when sameSite is 'None'
+      sameSite: 'None',
     })
     .json({ message: 'Logged out' });
 });


### PR DESCRIPTION
## Summary
- use secure SameSite=None cookies for register, login, and logout
- list frontend domain in CORS allowed origins
- send credentials with shared component fetches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc8f2749c83239662d736ca4cc346