### PR TITLE
feat: support cookie auth tokens

### DIFF
--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -2,7 +2,10 @@ import jwt from 'jsonwebtoken';
 
 export default function (req, res, next) {
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  let token = req.cookies?.token;
+  if (!token && authHeader) {
+    token = authHeader.split(' ')[1];
+  }
   if (!token) {
     return res.status(401).json({ error: 'No token provided' });
   }

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -37,7 +37,7 @@ router.post('/register', async (req, res) => {
     );
     
     res.cookie('token', token, cookieOptions);
-    res.status(201).json({ message: 'Registration successful' });
+    res.status(201).json({ message: 'Registration successful', token });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -61,7 +61,7 @@ router.post('/login', async (req, res) => {
     );
     
     res.cookie('token', token, cookieOptions);
-    res.json({ message: 'Login successful' });
+    res.json({ message: 'Login successful', token });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- allow auth middleware to read token from cookies with Authorization fallback
- return JWT token from login and register endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae55ca8a888323aac7949a3de8a8f8