### PR TITLE
fix: update CORS origins for backend

### DIFF
--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -11,20 +11,20 @@ const PORT = process.env.PORT || 5000;
 // CORS configuration
 const envOrigins = (process.env.ALLOWED_ORIGINS || '')
   .split(',')
-  .map((origin) => origin.trim())
+  .map((origin) => origin.trim().replace(/\/$/, ''))
   .filter(Boolean);
 
 const exactOrigins = [
   ...envOrigins,
-  process.env.FRONTEND_URL,       // e.g. https://betting-tracker-nine.vercel.app
-  process.env.FRONTEND_URL_ALT,   // e.g. https://your-custom-domain.com
+  process.env.FRONTEND_URL?.replace(/\/$/, ''),       // e.g. https://betting-tracker.vercel.app
+  process.env.FRONTEND_URL_ALT?.replace(/\/$/, ''),   // e.g. https://your-custom-domain.com
   'http://localhost:3000',
   'http://localhost:5173',
 ].filter(Boolean);
 
 // Allow preview URLs of the frontend project on Vercel
 const previewRegexes = [
-  /^https?:\/\/betting-tracker-nine(-[a-z0-9-]+)?\.vercel\.app$/i
+  /^https?:\/\/betting-tracker(-[a-z0-9-]+)?\.vercel\.app$/i,
 ];
 
 const corsOptions = {


### PR DESCRIPTION
## Summary
- sanitize env-provided origins to remove trailing slashes
- support all Vercel preview subdomains via regex

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae62fea9108323a0f9a5cbfd213503