### PR TITLE
feat: add cookie-based auth support

### DIFF
--- a/betting-tracker-backend/middleware/auth.js
+++ b/betting-tracker-backend/middleware/auth.js
@@ -1,8 +1,11 @@
 const jwt = require('jsonwebtoken');
 
 module.exports = function (req, res, next) {
+  const tokenFromCookie = req.cookies ? req.cookies.token : null;
   const authHeader = req.headers['authorization'];
-  const token = authHeader && authHeader.split(' ')[1];
+  const tokenFromHeader = authHeader && authHeader.split(' ')[1];
+  const token = tokenFromCookie || tokenFromHeader;
+
   if (!token) {
     return res.status(401).json({ error: 'No token provided' });
   }

--- a/betting-tracker-backend/package.json
+++ b/betting-tracker-backend/package.json
@@ -13,6 +13,7 @@
   "description": "",
   "dependencies": {
     "bcrypt": "^5.1.0",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const cors = require('cors');
+const cookieParser = require('cookie-parser');
 require('dotenv').config();
 const auth = require('./middleware/auth');
 const logger = require('./utils/logger');
@@ -51,6 +52,7 @@ app.use((req, res, next) => {
 });
 
 app.use(express.json());
+app.use(cookieParser());
 
 // MongoDB Connection
 mongoose.connect(process.env.MONGO_URI, {


### PR DESCRIPTION
## Summary
- add token cookie for register and login
- add /check and /logout auth endpoints
- support cookie tokens in auth middleware and server

## Testing
- `npm test`
- `curl -i http://localhost:5000/api/auth/check`
- `curl -i --cookie "token=$TOKEN" http://localhost:5000/api/auth/check`
- `curl -i --cookie "token=$TOKEN" -X POST http://localhost:5000/api/auth/logout`
- `curl -i --max-time 5 http://localhost:5000/api/bets`
- `curl -i --max-time 5 --cookie "token=$TOKEN" http://localhost:5000/api/bets`


------
https://chatgpt.com/codex/tasks/task_e_68b4ebe62a5883239f5ff6e0e429ff17