### PR TITLE
Allow admins to edit bet entries

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,11 +1,12 @@
 import { bets, fetchBets, loadDemoData as loadDemoBets, exportToCSV } from './bets.js';
-import { initForm, handleAddBet, saveFormData } from './form.js';
+import { initForm, handleAddBet, saveFormData, startEditBet } from './form.js';
 import { renderBets, handleRemoveBet, handleSettleBet, showTableLoading } from './render.js';
 import { updateStats } from './stats.js';
 import { showFullText, closeModal, showLearnMore } from './modal.js';
 
 // Always make core functions globally available for buttons
 window.addBet = handleAddBet;
+window.startEditBet = startEditBet;
 window.removeBet = handleRemoveBet;
 window.loadDemoData = async () => {
   loadDemoBets();

--- a/js/bets.js
+++ b/js/bets.js
@@ -56,6 +56,26 @@ export async function addBet(bet) {
   }
 }
 
+/** Update an existing bet */
+export async function updateBet(betId, updates) {
+  try {
+    const res = await fetch(`${API_URL}/${betId}`, {
+      method: 'PUT',
+      headers: authHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(updates),
+    });
+    if (!res.ok) throw new Error('Failed to update bet');
+    const updatedBet = await res.json();
+    const index = bets.findIndex(b => b._id === betId);
+    if (index !== -1) {
+      bets[index] = updatedBet;
+    }
+  } catch (err) {
+    console.error('❌ Error updating bet:', err.message);
+    alert(err.message || 'Failed to update bet');
+  }
+}
+
 /** Remove a bet by _id */
 export async function removeBet(betId) {
   try {

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,4 +1,4 @@
-import { formatDate, escapeHtml } from './utils.js';
+import { formatDate, escapeHtml, decodeToken } from './utils.js';
 
 let activeModal = null;
 let previousFocus = null;
@@ -71,6 +71,8 @@ export function showBetDetails(bet) {
   const modal = document.getElementById('betDetailsModal');
   const body = document.getElementById('betDetailsBody');
   if (modal && body) {
+    const token = localStorage.getItem('token');
+    const user = token ? decodeToken(token) : null;
     const details = [
       { label: 'Outcome', value: escapeHtml(bet.outcome), class: `status ${bet.outcome.toLowerCase()}` },
       { label: 'Description', value: escapeHtml(bet.description || ''), class: '' },
@@ -92,7 +94,7 @@ export function showBetDetails(bet) {
     body.innerHTML = '';
     const actions = document.createElement('div');
     actions.className = 'modal-actions';
-    actions.innerHTML =
+    let actionsHTML =
       bet.outcome === 'Pending'
         ? `
           <select onchange="settleBet(this, '${bet._id}'); closeModal();">
@@ -104,6 +106,10 @@ export function showBetDetails(bet) {
           <button class="btn btn-danger" onclick="removeBet('${bet._id}'); closeModal();">Remove</button>
         `
         : `<button class="btn btn-danger" onclick="removeBet('${bet._id}'); closeModal();">Remove</button>`;
+    if (user?.role === 'admin') {
+      actionsHTML += `<button class="btn" onclick="startEditBet('${bet._id}'); closeModal();">Edit</button>`;
+    }
+    actions.innerHTML = actionsHTML;
     body.appendChild(actions);
 
     details.forEach(detail => {


### PR DESCRIPTION
## Summary
- allow updating bets via new update API helper
- enable form editing through `startEditBet`
- add admin-only edit button in bet details modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c485a486708323b8bad3c6323c3e99