### PR TITLE
Add AI analyst chat experience with secure OpenAI key handling

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AI Analyst</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <div class="container ai-page">
+    <div id="include-header"></div>
+    <div id="include-stats"></div>
+
+    <div class="ai-layout" id="ai-layout">
+      <section class="ai-chat" aria-label="AI analyst conversation">
+        <div class="ai-thread" id="ai-thread"></div>
+        <div class="ai-input" id="ai-input">
+          <div class="scope-selector" role="group" aria-label="Analysis scope">
+            <label><input type="radio" name="analysisScope" value="all" checked> Analyze all bets</label>
+            <label><input type="radio" name="analysisScope" value="filtered"> Analyze current filters</label>
+          </div>
+          <div class="filter-controls" id="filter-controls" hidden>
+            <div class="filter-row">
+              <label>
+                From
+                <input type="date" id="filter-start" />
+              </label>
+              <label>
+                To
+                <input type="date" id="filter-end" />
+              </label>
+            </div>
+            <div class="filter-row">
+              <label>
+                Sports
+                <select id="filter-sports" multiple size="4"></select>
+              </label>
+              <label>
+                Markets
+                <select id="filter-markets" multiple size="4"></select>
+              </label>
+              <label>
+                Outcomes
+                <select id="filter-outcomes" multiple size="4"></select>
+              </label>
+            </div>
+            <button class="btn btn-secondary" id="apply-filters-btn">Apply filters</button>
+          </div>
+          <div class="ai-input-row">
+            <textarea id="ai-question" rows="2" placeholder="Ask about performance, trends, or strategy..." aria-label="Ask the analyst"></textarea>
+            <button class="btn" id="send-question-btn">Send</button>
+          </div>
+          <div class="ai-hints" id="ai-hints"></div>
+        </div>
+      </section>
+
+      <aside class="ai-context" aria-label="Analysis context">
+        <div class="context-card">
+          <h2>Snapshot</h2>
+          <div class="context-metrics" id="context-metrics"></div>
+          <div class="context-extra" id="context-extra"></div>
+        </div>
+        <div class="context-card">
+          <h3>Chart</h3>
+          <canvas id="ai-chart" width="320" height="220" role="img" aria-label="AI generated chart"></canvas>
+          <p class="chart-caption" id="chart-caption"></p>
+        </div>
+        <div class="context-card">
+          <h3>Breakdowns</h3>
+          <div class="context-breakdowns" id="context-breakdowns"></div>
+        </div>
+        <div class="context-card">
+          <h3>Follow-up ideas</h3>
+          <ul id="follow-ups" class="follow-ups"></ul>
+        </div>
+      </aside>
+    </div>
+  </div>
+
+  <script src="js/loadShared.js"></script>
+  <script type="module" src="js/ai.js"></script>
+  <script src="js/auth.js"></script>
+  <script>
+    window.addEventListener('shared:loaded', () => {
+      const title = document.getElementById('page-title');
+      const subtitle = document.getElementById('page-subtitle');
+      const learnMore = document.getElementById('learn-more-link');
+      if (title) title.textContent = '🤖 AI Analyst';
+      if (subtitle) subtitle.textContent = 'Chat with your betting data specialist';
+      if (learnMore) learnMore.style.display = 'none';
+    });
+  </script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -272,6 +272,15 @@ body {
   background: #c0392b;
 }
 
+.btn-secondary {
+  background: #7f8c8d;
+  color: #fff;
+}
+
+.btn-secondary:hover {
+  background: #707b7c;
+}
+
 .danger-link {
   color: #e74c3c;
   cursor: pointer;
@@ -397,6 +406,313 @@ tr:hover {
   padding: 20px;
   color: #7f8c8d;
   font-style: italic;
+}
+
+.muted {
+  color: #6b7a8f;
+  font-size: 13px;
+}
+
+.form-help {
+  font-size: 12px;
+  color: #6b7a8f;
+  margin-top: 6px;
+}
+
+.button-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+}
+
+.ai-controls {
+  margin-top: 24px;
+  padding-top: 12px;
+  border-top: 1px solid #dfe4ea;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ai-page .ai-layout {
+  display: flex;
+  gap: 24px;
+  margin: 30px 0 60px;
+  flex-wrap: wrap;
+}
+
+.ai-chat {
+  flex: 1 1 58%;
+  min-width: 320px;
+  background: #ffffff;
+  border: 1px solid #dfe4ea;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 12px 24px rgba(0,0,0,0.05);
+}
+
+.ai-thread {
+  flex: 1;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow-y: auto;
+  background: linear-gradient(180deg, #f6f9fc 0%, #ffffff 100%);
+}
+
+.message {
+  display: flex;
+  width: 100%;
+}
+
+.message.user {
+  justify-content: flex-end;
+}
+
+.message.assistant {
+  justify-content: flex-start;
+}
+
+.message.system {
+  justify-content: center;
+}
+
+.bubble {
+  max-width: 80%;
+  padding: 12px 16px;
+  border-radius: 14px;
+  line-height: 1.5;
+  font-size: 14px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.05);
+}
+
+.message.user .bubble {
+  background: #1f78d1;
+  color: #ffffff;
+  border-bottom-right-radius: 4px;
+}
+
+.message.assistant .bubble {
+  background: #eef4ff;
+  color: #1f2a37;
+  border-bottom-left-radius: 4px;
+}
+
+.message.system .bubble {
+  background: #ecf0f1;
+  color: #4a4a4a;
+  border-radius: 8px;
+  font-style: italic;
+}
+
+.ai-input {
+  padding: 16px 20px 20px;
+  border-top: 1px solid #e1e5ea;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: #ffffff;
+}
+
+.ai-input textarea {
+  width: 100%;
+  border: 1px solid #ccd6e0;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 14px;
+  resize: vertical;
+  min-height: 60px;
+}
+
+.ai-input-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.ai-input-row textarea {
+  flex: 1;
+}
+
+.scope-selector {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  font-size: 13px;
+  color: #34495e;
+}
+
+.scope-selector label {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.filter-controls {
+  background: #f1f5fb;
+  border: 1px solid #d7e2f2;
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.filter-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.filter-row label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #2c3e50;
+  display: flex;
+  flex-direction: column;
+}
+
+.filter-row input,
+.filter-row select {
+  min-width: 150px;
+  padding: 6px;
+  border-radius: 6px;
+  border: 1px solid #cdd6e1;
+  font-size: 13px;
+}
+
+.ai-hints {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hint-chip {
+  background: #ecf0f1;
+  border: none;
+  border-radius: 20px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-size: 12px;
+  color: #34495e;
+}
+
+.hint-chip:hover {
+  background: #d7dde2;
+}
+
+.ai-context {
+  flex: 1 1 32%;
+  min-width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.context-card {
+  background: #ffffff;
+  border: 1px solid #dfe4ea;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 10px 20px rgba(0,0,0,0.04);
+}
+
+.context-card h2,
+.context-card h3,
+.context-card h4 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  color: #2c3e50;
+}
+
+.metric-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.metric-label {
+  color: #5f6c7b;
+}
+
+.metric-value {
+  font-weight: 600;
+  color: #1f2a37;
+}
+
+.issue-list {
+  margin-top: 10px;
+  padding-left: 18px;
+  color: #d35400;
+  font-size: 12px;
+}
+
+.context-breakdowns ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+}
+
+.context-breakdowns li {
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.follow-ups {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.follow-ups button {
+  background: #ecf0f1;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.follow-ups button:hover {
+  background: #d7dde2;
+}
+
+#ai-chart {
+  width: 100%;
+  background: #f7f9fb;
+  border: 1px solid #e0e6ee;
+  border-radius: 10px;
+}
+
+.chart-caption {
+  font-size: 12px;
+  color: #6b7a8f;
+  margin-top: 8px;
+}
+
+@media (max-width: 900px) {
+  .ai-page .ai-layout {
+    flex-direction: column;
+  }
+
+  .ai-chat,
+  .ai-context {
+    flex: 1 1 100%;
+  }
+
+  .bubble {
+    max-width: 100%;
+  }
 }
 
 .download-section {

--- a/index.html
+++ b/index.html
@@ -96,6 +96,14 @@
       <!-- Row 3 -->
       <div class="form-row">
         <div class="form-group">
+          <label for="closingOdds">Closing Odds (optional)</label>
+          <input type="text" id="closingOdds" placeholder="Final line e.g. -115">
+        </div>
+        <div class="form-group">
+          <label for="sportsbook">Sportsbook (optional)</label>
+          <input type="text" id="sportsbook" placeholder="Where you placed it">
+        </div>
+        <div class="form-group">
           <label for="note">Note</label>
           <input type="text" id="note" placeholder="Optional" />
         </div>

--- a/js/ai.js
+++ b/js/ai.js
@@ -1,0 +1,540 @@
+import { API_BASE_URL } from './config.js';
+import { escapeHtml } from './utils.js';
+
+const threadEl = document.getElementById('ai-thread');
+const questionInput = document.getElementById('ai-question');
+const sendBtn = document.getElementById('send-question-btn');
+const hintsEl = document.getElementById('ai-hints');
+const contextMetricsEl = document.getElementById('context-metrics');
+const contextExtraEl = document.getElementById('context-extra');
+const breakdownsEl = document.getElementById('context-breakdowns');
+const followUpsEl = document.getElementById('follow-ups');
+const chartCanvas = document.getElementById('ai-chart');
+const chartCaption = document.getElementById('chart-caption');
+const filterControls = document.getElementById('filter-controls');
+const applyFiltersBtn = document.getElementById('apply-filters-btn');
+const scopeRadios = document.querySelectorAll('input[name="analysisScope"]');
+
+let currentScope = 'all';
+let selectedFilters = {};
+let conversation = [];
+let isStreaming = false;
+let lastContext = null;
+let defaultHints = [
+  'What does my ROI look like this season?',
+  'Show profit by sport.',
+  'Where am I running cold?'
+];
+
+function getToken() {
+  return localStorage.getItem('token');
+}
+
+function ensureLoggedIn() {
+  const token = getToken();
+  if (!token) {
+    appendSystemMessage('Sign in and save your OpenAI key in Settings to chat with the analyst.');
+    if (questionInput) questionInput.disabled = true;
+    if (sendBtn) sendBtn.disabled = true;
+    return false;
+  }
+  return true;
+}
+
+function appendMessage(role, text = '') {
+  if (!threadEl) return null;
+  const wrapper = document.createElement('div');
+  wrapper.className = `message ${role}`;
+  const bubble = document.createElement('div');
+  bubble.className = 'bubble';
+  bubble.innerHTML = escapeHtml(text).replace(/\n/g, '<br>');
+  wrapper.appendChild(bubble);
+  threadEl.appendChild(wrapper);
+  threadEl.scrollTop = threadEl.scrollHeight;
+  return bubble;
+}
+
+function setBubbleText(bubble, text) {
+  if (!bubble) return;
+  bubble.innerHTML = escapeHtml(text).replace(/\n/g, '<br>');
+  threadEl.scrollTop = threadEl.scrollHeight;
+}
+
+function appendSystemMessage(text) {
+  appendMessage('system', text);
+}
+
+function renderHints(hints) {
+  if (!hintsEl) return;
+  const list = hints && hints.length ? hints : defaultHints;
+  hintsEl.innerHTML = '';
+  list.forEach(hint => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'hint-chip';
+    button.textContent = hint;
+    button.addEventListener('click', () => {
+      if (questionInput) {
+        questionInput.value = hint;
+        questionInput.focus();
+      }
+    });
+    hintsEl.appendChild(button);
+  });
+}
+
+function formatNumber(value, options = {}) {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  if (typeof value !== 'number') return value;
+  if (options.type === 'currency') {
+    return (value < 0 ? '-' : '') + '$' + Math.abs(value).toFixed(options.decimals ?? 2);
+  }
+  if (options.type === 'percent') {
+    return (value >= 0 ? '+' : '') + value.toFixed(options.decimals ?? 1) + '%';
+  }
+  return value.toLocaleString(undefined, { maximumFractionDigits: options.decimals ?? 2 });
+}
+
+function renderMetrics(metrics) {
+  if (!contextMetricsEl || !metrics) return;
+  const items = [
+    { label: 'Total Bets', value: metrics.totalBets },
+    { label: 'Win Rate', value: metrics.winRatePct, format: 'percent' },
+    { label: 'ROI', value: metrics.roiPct, format: 'percent' },
+    { label: 'Net Profit', value: metrics.netProfit, format: 'currency' },
+    { label: 'Avg Odds (decimal)', value: metrics.avgOdds, format: null },
+    { label: 'CLV', value: metrics.clvPct, format: 'percent' },
+    { label: 'Longest Win Streak', value: metrics.longestWinStreak },
+    { label: 'Longest Loss Streak', value: metrics.longestLossStreak },
+  ];
+  contextMetricsEl.innerHTML = items
+    .map(item => `
+      <div class="metric-row">
+        <span class="metric-label">${escapeHtml(item.label)}</span>
+        <span class="metric-value">${formatNumber(item.value, item.format === 'currency'
+          ? { type: 'currency' }
+          : item.format === 'percent'
+            ? { type: 'percent', decimals: 1 }
+            : { maximumFractionDigits: 2 })}</span>
+      </div>
+    `)
+    .join('');
+}
+
+function renderExtra(context) {
+  if (!contextExtraEl || !context?.dataset) return;
+  const { dataset, issues } = context;
+  const rows = [
+    { label: 'Scope', value: context.scope === 'filtered' ? 'Filtered slice' : 'All bets' },
+    { label: 'Resolved', value: dataset.resolvedBets },
+    { label: 'Pending', value: dataset.pendingBets },
+    { label: 'Pending Exposure', value: formatNumber(dataset.pendingExposure, { type: 'currency' }) },
+    { label: 'Date Range', value: dataset.firstBetDate && dataset.lastBetDate
+        ? `${dataset.firstBetDate.slice(0, 10)} → ${dataset.lastBetDate.slice(0, 10)}`
+        : '—' },
+    { label: 'Closing Odds Coverage', value: formatNumber(dataset.closingCoveragePct, { type: 'percent', decimals: 1 }) },
+  ];
+  contextExtraEl.innerHTML = rows
+    .map(row => `
+      <div class="metric-row">
+        <span class="metric-label">${escapeHtml(row.label)}</span>
+        <span class="metric-value">${typeof row.value === 'string' ? escapeHtml(row.value) : row.value}</span>
+      </div>
+    `)
+    .join('');
+
+  if (issues?.length) {
+    const issuesList = document.createElement('ul');
+    issuesList.className = 'issue-list';
+    issues.forEach(issue => {
+      const li = document.createElement('li');
+      li.textContent = issue;
+      issuesList.appendChild(li);
+    });
+    contextExtraEl.appendChild(issuesList);
+  }
+}
+
+function renderBreakdowns(breakdowns) {
+  if (!breakdownsEl) return;
+  const bySportEntries = Object.entries(breakdowns?.bySport || {});
+  const byMarketEntries = Object.entries(breakdowns?.byMarket || {});
+  const monthEntries = breakdowns?.byMonth || [];
+
+  const sportHtml = bySportEntries.length
+    ? `<h4>By Sport</h4><ul>${bySportEntries
+        .map(([sport, data]) => `<li><strong>${escapeHtml(sport)}:</strong> ${formatNumber(data.netProfit, { type: 'currency' })} (${formatNumber(data.roiPct, { type: 'percent', decimals: 1 })} ROI)</li>`)
+        .join('')}</ul>`
+    : '';
+  const marketHtml = byMarketEntries.length
+    ? `<h4>By Market</h4><ul>${byMarketEntries
+        .map(([market, data]) => `<li><strong>${escapeHtml(market)}:</strong> ${formatNumber(data.netProfit, { type: 'currency' })} (${formatNumber(data.roiPct, { type: 'percent', decimals: 1 })} ROI)</li>`)
+        .join('')}</ul>`
+    : '';
+  const monthHtml = monthEntries.length
+    ? `<h4>Monthly Net</h4><ul>${monthEntries
+        .map(point => `<li>${escapeHtml(String(point.x))}: ${formatNumber(point.y, { type: 'currency' })}</li>`)
+        .join('')}</ul>`
+    : '';
+  breakdownsEl.innerHTML = sportHtml + marketHtml + monthHtml || '<p class="muted">Breakdown data will appear after your first analysis.</p>';
+}
+
+function renderFollowUps(followUps) {
+  if (!followUpsEl) return;
+  followUpsEl.innerHTML = '';
+  (followUps || []).forEach(question => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = question;
+    btn.addEventListener('click', () => {
+      if (questionInput) {
+        questionInput.value = question;
+        questionInput.focus();
+      }
+    });
+    li.appendChild(btn);
+    followUpsEl.appendChild(li);
+  });
+}
+
+function clearChart() {
+  if (!chartCanvas) return;
+  const ctx = chartCanvas.getContext('2d');
+  ctx.clearRect(0, 0, chartCanvas.width, chartCanvas.height);
+  chartCaption.textContent = '';
+}
+
+function drawChart(chart, fallbackSeries) {
+  if (!chartCanvas) return;
+  const ctx = chartCanvas.getContext('2d');
+  ctx.clearRect(0, 0, chartCanvas.width, chartCanvas.height);
+
+  const series = chart?.series?.length ? chart.series : fallbackSeries ? [{ name: 'Net Profit', points: fallbackSeries }] : [];
+  if (!series.length || !series[0].points?.length) {
+    chartCaption.textContent = 'No chart available for this slice yet.';
+    return;
+  }
+  const points = series[0].points;
+  const padding = 30;
+  const width = chartCanvas.width - padding * 2;
+  const height = chartCanvas.height - padding * 2;
+  const values = points.map(p => p.y);
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const range = maxVal - minVal || 1;
+
+  ctx.strokeStyle = '#1f78d1';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  points.forEach((point, index) => {
+    const x = padding + (index / Math.max(points.length - 1, 1)) * width;
+    const y = padding + (1 - (point.y - minVal) / range) * height;
+    if (index === 0) {
+      ctx.moveTo(x, y);
+    } else {
+      ctx.lineTo(x, y);
+    }
+  });
+  ctx.stroke();
+
+  if (chart?.type === 'area') {
+    ctx.lineTo(padding + width, padding + height);
+    ctx.lineTo(padding, padding + height);
+    ctx.closePath();
+    ctx.fillStyle = 'rgba(31,120,209,0.15)';
+    ctx.fill();
+  }
+
+  if (chart?.type === 'bar') {
+    ctx.clearRect(0, 0, chartCanvas.width, chartCanvas.height);
+    ctx.fillStyle = '#1f78d1';
+    const barWidth = width / points.length * 0.6;
+    points.forEach((point, index) => {
+      const x = padding + index * (width / points.length) + (width / points.length - barWidth) / 2;
+      const y = padding + (1 - (point.y - minVal) / range) * height;
+      const barHeight = padding + height - y;
+      ctx.fillRect(x, y, barWidth, barHeight);
+    });
+    ctx.strokeStyle = '#1f78d1';
+  }
+
+  ctx.fillStyle = '#2c3e50';
+  ctx.font = '12px sans-serif';
+  points.forEach((point, index) => {
+    const x = padding + (index / Math.max(points.length - 1, 1)) * width;
+    const y = padding + (1 - (point.y - minVal) / range) * height;
+    ctx.beginPath();
+    ctx.arc(x, y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  chartCaption.textContent = chart?.title || 'Performance trend';
+}
+
+function renderContext(payload) {
+  if (!payload) return;
+  renderMetrics(payload.metrics);
+  renderExtra(payload.context);
+  renderBreakdowns(payload.breakdowns);
+  renderFollowUps(payload.followUps);
+  const fallback = payload.breakdowns?.byMonth;
+  drawChart(payload.chart, fallback);
+}
+
+async function loadContext({ scope = currentScope, filters = selectedFilters } = {}) {
+  const token = getToken();
+  if (!token) return;
+  const params = new URLSearchParams();
+  if (scope === 'filtered') {
+    Object.entries(filters || {}).forEach(([key, value]) => {
+      if (!value) return;
+      if (Array.isArray(value)) {
+        value.forEach(v => params.append(key, v));
+      } else {
+        params.set(key, value);
+      }
+    });
+  }
+  const url = `${API_BASE_URL}/ai/context${params.toString() ? `?${params}` : ''}`;
+  try {
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) {
+      throw new Error('Failed to load AI context');
+    }
+    const data = await res.json();
+    lastContext = {
+      metrics: data.metrics,
+      breakdowns: data.breakdowns,
+      chart: null,
+      followUps: [],
+      context: {
+        scope: data.scope,
+        filters: data.filters,
+        dataset: data.dataset,
+        drawdown: data.drawdown,
+        issues: data.issues,
+      },
+    };
+    renderMetrics(lastContext.metrics);
+    renderExtra(lastContext.context);
+    renderBreakdowns(lastContext.breakdowns);
+    drawChart(null, data.breakdowns?.byMonth);
+    renderHints();
+    populateFilterOptions(data.availableFilters);
+    if (!data.aiKeyConfigured) {
+      appendSystemMessage('Add your OpenAI API key in Settings to enable the AI analyst.');
+      if (questionInput) questionInput.disabled = true;
+      if (sendBtn) sendBtn.disabled = true;
+    }
+  } catch (err) {
+    console.error('❌ Error loading AI context:', err.message);
+    appendSystemMessage('Unable to load AI context. Please refresh.');
+  }
+}
+
+function populateFilterOptions(facets) {
+  if (!facets) return;
+  const sportsSelect = document.getElementById('filter-sports');
+  const marketsSelect = document.getElementById('filter-markets');
+  const outcomesSelect = document.getElementById('filter-outcomes');
+
+  function fillSelect(select, values) {
+    if (!select) return;
+    const existing = new Set(Array.from(select.options).map(opt => opt.value));
+    values.forEach(value => {
+      if (!existing.has(value)) {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = value;
+        select.appendChild(option);
+      }
+    });
+  }
+
+  fillSelect(sportsSelect, facets.sports || []);
+  fillSelect(marketsSelect, facets.betTypes || []);
+  fillSelect(outcomesSelect, facets.outcomes || []);
+}
+
+function readFiltersFromForm() {
+  const filters = {};
+  const start = document.getElementById('filter-start')?.value;
+  const end = document.getElementById('filter-end')?.value;
+  if (start) filters.startDate = start;
+  if (end) filters.endDate = end;
+  const sports = document.getElementById('filter-sports');
+  const markets = document.getElementById('filter-markets');
+  const outcomes = document.getElementById('filter-outcomes');
+  if (sports) {
+    const values = Array.from(sports.selectedOptions).map(opt => opt.value);
+    if (values.length) filters.sports = values;
+  }
+  if (markets) {
+    const values = Array.from(markets.selectedOptions).map(opt => opt.value);
+    if (values.length) filters.betTypes = values;
+  }
+  if (outcomes) {
+    const values = Array.from(outcomes.selectedOptions).map(opt => opt.value);
+    if (values.length) filters.outcomes = values;
+  }
+  return filters;
+}
+
+function buildRequestBody(message) {
+  return {
+    message,
+    scope: currentScope,
+    filters: currentScope === 'filtered' ? selectedFilters : {},
+    history: conversation.slice(-6),
+  };
+}
+
+function handleSseEvent(event, data, streamState) {
+  switch (event) {
+    case 'token': {
+      streamState.buffer += data;
+      setBubbleText(streamState.bubble, streamState.buffer);
+      break;
+    }
+    case 'payload': {
+      try {
+        const payload = JSON.parse(data);
+        streamState.finalPayload = payload;
+        setBubbleText(streamState.bubble, payload.answer || streamState.buffer);
+        renderContext(payload);
+        renderHints(payload.followUps);
+      } catch (err) {
+        console.error('❌ Failed to parse payload:', err.message);
+      }
+      break;
+    }
+    case 'error': {
+      appendSystemMessage('The analyst encountered an error. Please try again.');
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+async function streamAnalysis(message) {
+  const token = getToken();
+  if (!token) return;
+
+  const requestBody = buildRequestBody(message);
+  const response = await fetch(`${API_BASE_URL}/ai/analyze`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok || !response.body) {
+    const error = await response.json().catch(() => ({ error: 'Failed to reach AI analyst.' }));
+    throw new Error(error.error || 'Failed to reach AI analyst.');
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const streamState = { bubble: appendMessage('assistant', ''), buffer: '', finalPayload: null };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let boundary;
+    while ((boundary = buffer.indexOf('\n\n')) >= 0) {
+      const chunk = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      if (!chunk.trim()) continue;
+      const lines = chunk.split('\n');
+      const eventLine = lines.find(line => line.startsWith('event:'));
+      const dataLines = lines.filter(line => line.startsWith('data:')).map(line => line.replace(/^data:\s?/, ''));
+      const event = eventLine ? eventLine.replace('event:', '').trim() : 'message';
+      const data = dataLines.join('\n');
+      handleSseEvent(event, data, streamState);
+    }
+  }
+
+  if (buffer.trim()) {
+    const lines = buffer.split('\n');
+    const eventLine = lines.find(line => line.startsWith('event:'));
+    const dataLines = lines.filter(line => line.startsWith('data:')).map(line => line.replace(/^data:\s?/, ''));
+    const event = eventLine ? eventLine.replace('event:', '').trim() : 'message';
+    const data = dataLines.join('\n');
+    handleSseEvent(event, data, streamState);
+  }
+
+  return streamState.finalPayload || { answer: streamState.buffer };
+}
+
+async function onSend() {
+  if (isStreaming || !questionInput) return;
+  const message = questionInput.value.trim();
+  if (!message) return;
+  appendMessage('user', message);
+  conversation.push({ role: 'user', content: message });
+  questionInput.value = '';
+  isStreaming = true;
+  if (sendBtn) sendBtn.disabled = true;
+
+  try {
+    const payload = await streamAnalysis(message);
+    conversation.push({ role: 'assistant', content: payload.answer || '' });
+  } catch (err) {
+    console.error('❌ AI streaming error:', err.message);
+    appendSystemMessage(err.message);
+  } finally {
+    isStreaming = false;
+    if (sendBtn) sendBtn.disabled = false;
+  }
+}
+
+function initScopeControls() {
+  scopeRadios.forEach(radio => {
+    radio.addEventListener('change', () => {
+      currentScope = radio.value;
+      if (currentScope === 'filtered') {
+        filterControls?.removeAttribute('hidden');
+      } else {
+        filterControls?.setAttribute('hidden', '');
+        selectedFilters = {};
+        loadContext({ scope: 'all', filters: {} });
+      }
+    });
+  });
+
+  applyFiltersBtn?.addEventListener('click', async () => {
+    selectedFilters = readFiltersFromForm();
+    if (!Object.keys(selectedFilters).length) {
+      appendSystemMessage('Choose at least one filter or use the "Analyze all bets" option.');
+      return;
+    }
+    await loadContext({ scope: 'filtered', filters: selectedFilters });
+  });
+}
+
+function initInput() {
+  if (!questionInput) return;
+  questionInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      onSend();
+    }
+  });
+  sendBtn?.addEventListener('click', onSend);
+}
+
+async function init() {
+  if (!ensureLoggedIn()) return;
+  await loadContext();
+  initScopeControls();
+  initInput();
+  renderHints();
+}
+
+init();

--- a/js/bets.js
+++ b/js/bets.js
@@ -142,7 +142,7 @@ export async function settleBet(betId, newOutcome) {
 
 /** Export all bets to CSV */
 export function exportToCSV() {
-  const headers = ['Outcome', 'Event', 'Description', 'Bet Type', 'Odds', 'Stake', 'Payout', 'Profit/Loss', 'Date', 'Sport', 'Note'];
+  const headers = ['Outcome', 'Event', 'Description', 'Bet Type', 'Odds', 'Closing Odds', 'Stake', 'Payout', 'Profit/Loss', 'Date', 'Sport', 'Sportsbook', 'Note'];
 
   const csvContent = [
     headers.join(','),
@@ -152,11 +152,13 @@ export function exportToCSV() {
       `"${bet.description || ''}"`,
       bet.betType,
       bet.odds,
+      bet.closingOdds || '',
       parseFloat(bet.stake).toFixed(2),
       parseFloat(bet.payout).toFixed(2),
       bet.outcome === 'Pending' ? '' : parseFloat(bet.profitLoss).toFixed(2),
       formatDate(bet.date),
       bet.sport,
+      `"${(bet.sportsbook || '').replace(/"/g, '""')}"`,
       `"${bet.note || ''}"`
     ].join(','))
   ].join('\n');
@@ -180,11 +182,13 @@ export function loadDemoData() {
       description: 'Eagles -3.5',
       betType: 'Point Spread',
       odds: '-110',
+      closingOdds: '-118',
       stake: 110,
       payout: calculatePayout('-110', 110),
       profitLoss: calculatePayout('-110', 110) - 110,
       date: '2024-01-15T00:00:00.000Z',
       sport: 'NFL Football',
+      sportsbook: 'DraftKings',
       note: 'Sample win'
     },
     {
@@ -194,11 +198,13 @@ export function loadDemoData() {
       description: 'Lakers -2',
       betType: 'Point Spread',
       odds: '-105',
+      closingOdds: '-102',
       stake: 105,
       payout: 0,
       profitLoss: -105,
       date: '2024-02-20T00:00:00.000Z',
       sport: 'NBA Basketball',
+      sportsbook: 'FanDuel',
       note: 'Sample loss'
     },
     {
@@ -208,11 +214,13 @@ export function loadDemoData() {
       description: 'Over 8.5',
       betType: 'Over/Under',
       odds: '-110',
+      closingOdds: '-108',
       stake: 110,
       payout: 0,
       profitLoss: 0,
       date: '2024-03-10T00:00:00.000Z',
       sport: 'Baseball',
+      sportsbook: 'BetMGM',
       note: ''
     },
     {
@@ -222,11 +230,13 @@ export function loadDemoData() {
       description: 'Packers ML',
       betType: 'Moneyline',
       odds: '+120',
+      closingOdds: '+110',
       stake: 100,
       payout: calculatePayout('+120', 100),
       profitLoss: calculatePayout('+120', 100) - 100,
       date: '2024-04-12T00:00:00.000Z',
       sport: 'NFL Football',
+      sportsbook: 'DraftKings',
       note: 'Dog hits'
     },
     {
@@ -236,11 +246,13 @@ export function loadDemoData() {
       description: 'Over 210.5',
       betType: 'Over/Under',
       odds: '-110',
+      closingOdds: '-105',
       stake: 110,
       payout: 0,
       profitLoss: -110,
       date: '2024-05-01T00:00:00.000Z',
       sport: 'NBA Basketball',
+      sportsbook: 'FanDuel',
       note: 'High scoring attempt'
     },
     {
@@ -250,11 +262,13 @@ export function loadDemoData() {
       description: 'Under 43.5',
       betType: 'Over/Under',
       odds: '-105',
+      closingOdds: '-103',
       stake: 105,
       payout: 0,
       profitLoss: 0,
       date: '2024-06-15T00:00:00.000Z',
       sport: 'NFL Football',
+      sportsbook: 'Caesars',
       note: ''
     },
     {
@@ -264,11 +278,13 @@ export function loadDemoData() {
       description: 'Hurricanes +1.5',
       betType: 'Puck Line',
       odds: '-130',
+      closingOdds: '-135',
       stake: 130,
       payout: calculatePayout('-130', 130),
       profitLoss: calculatePayout('-130', 130) - 130,
       date: '2024-07-20T00:00:00.000Z',
       sport: 'NHL Hockey',
+      sportsbook: 'BetMGM',
       note: 'Sample hockey win'
     },
     {
@@ -278,11 +294,13 @@ export function loadDemoData() {
       description: 'Spain +1',
       betType: 'Point Spread',
       odds: '-110',
+      closingOdds: '-110',
       stake: 110,
       payout: 110,
       profitLoss: 0,
       date: '2024-08-05T00:00:00.000Z',
       sport: 'Soccer',
+      sportsbook: 'PointsBet',
       note: 'Push sample'
     }
   ];

--- a/js/form.js
+++ b/js/form.js
@@ -2,7 +2,7 @@ import { addBet as addBetData, calculatePayout, updateBet as updateBetData, bets
 import { renderBets } from './render.js';
 import { updateStats } from './stats.js';
 
-const FORM_FIELDS = ['date', 'sport', 'event', 'betType', 'odds', 'stake', 'outcome', 'description', 'note'];
+const FORM_FIELDS = ['date', 'sport', 'event', 'betType', 'odds', 'stake', 'outcome', 'description', 'note', 'closingOdds', 'sportsbook'];
 
 let editingBetId = null;
 
@@ -85,6 +85,19 @@ export async function handleAddBet() {
   const outcome = document.getElementById('outcome').value;
   const description = document.getElementById('description').value.trim();
   const note = document.getElementById('note').value.trim();
+  const closingOddsInput = document.getElementById('closingOdds').value.trim();
+  let closingOdds = closingOddsInput;
+  const closingNum = parseFloat(closingOddsInput);
+  if (
+    closingOddsInput &&
+    !closingOddsInput.startsWith('+') &&
+    !closingOddsInput.startsWith('-') &&
+    !isNaN(closingNum) &&
+    Math.abs(closingNum) >= 100
+  ) {
+    closingOdds = `${closingNum > 0 ? '+' : ''}${closingOddsInput}`;
+  }
+  const sportsbook = document.getElementById('sportsbook').value.trim();
 
   if (!date || !sport || !event || !betType || !odds || !stake || !outcome) {
     alert('Please fill in all required fields');
@@ -116,7 +129,9 @@ export async function handleAddBet() {
     payout,
     profitLoss,
     description,
-    note
+    note,
+    closingOdds,
+    sportsbook,
   };
 
   try {
@@ -135,7 +150,7 @@ export async function handleAddBet() {
 }
 
 export function clearForm() {
-  const fields = ['event', 'odds', 'stake', 'payout', 'outcome', 'description', 'note'];
+  const fields = ['event', 'odds', 'stake', 'payout', 'outcome', 'description', 'note', 'closingOdds', 'sportsbook'];
   fields.forEach(id => {
     const el = document.getElementById(id);
     if (el) el.value = '';
@@ -155,7 +170,7 @@ export function startEditBet(betId) {
     const d = new Date(bet.date);
     dateEl.value = d.toISOString().split('T')[0];
   }
-  const fields = ['sport', 'event', 'betType', 'odds', 'stake', 'outcome', 'description', 'note'];
+  const fields = ['sport', 'event', 'betType', 'odds', 'stake', 'outcome', 'description', 'note', 'closingOdds', 'sportsbook'];
   fields.forEach(id => {
     const el = document.getElementById(id);
     if (el) el.value = bet[id] ?? '';

--- a/js/modal.js
+++ b/js/modal.js
@@ -121,6 +121,11 @@ export function showBetDetails(bet) {
             : ''
       },
       { label: 'Stake', value: `$${parseFloat(currentBet.stake).toFixed(2)}`, class: '' },
+      {
+        label: 'Closing Odds',
+        value: escapeHtml(currentBet.closingOdds || '—'),
+        class: '',
+      },
       { label: 'Payout', value: `$${parseFloat(currentBet.payout).toFixed(2)}`, class: currentBet.payout > 0 ? 'positive' : '' },
       {
         label: 'Profit/Loss',
@@ -140,6 +145,7 @@ export function showBetDetails(bet) {
       { label: 'Date', value: formatDate(currentBet.date), class: '' },
       { label: 'Event', value: escapeHtml(currentBet.event), class: '' },
       { label: 'Sport', value: escapeHtml(currentBet.sport), class: '' },
+      { label: 'Sportsbook', value: escapeHtml(currentBet.sportsbook || '—'), class: '' },
       { label: 'Note', value: escapeHtml(currentBet.note || ''), class: '', fullWidth: true }
     ];
 
@@ -179,6 +185,8 @@ export function showBetDetails(bet) {
           <option value="Push" ${currentBet.outcome === 'Push' ? 'selected' : ''}>Push</option>
         </select>
       </label>
+      <label>Closing Odds<input type="text" id="edit-closingOdds" value="${escapeHtml(currentBet.closingOdds || '')}"></label>
+      <label>Sportsbook<input type="text" id="edit-sportsbook" value="${escapeHtml(currentBet.sportsbook || '')}"></label>
       <label>Description<input type="text" id="edit-description" value="${escapeHtml(currentBet.description || '')}"></label>
       <label>Note<textarea id="edit-note">${escapeHtml(currentBet.note || '')}</textarea></label>
     `;
@@ -200,7 +208,9 @@ export function showBetDetails(bet) {
         stake: parseFloat(document.getElementById('edit-stake').value) || 0,
         outcome: document.getElementById('edit-outcome').value,
         description: document.getElementById('edit-description').value.trim(),
-        note: document.getElementById('edit-note').value.trim()
+        note: document.getElementById('edit-note').value.trim(),
+        closingOdds: document.getElementById('edit-closingOdds').value.trim(),
+        sportsbook: document.getElementById('edit-sportsbook').value.trim(),
       };
 
       let payout = 0;

--- a/js/render.js
+++ b/js/render.js
@@ -86,6 +86,8 @@ export function renderBets() {
     const safeBetType = escapeHtml(bet.betType);
     const safeOdds = escapeHtml(bet.odds);
     const safeSport = escapeHtml(bet.sport);
+    const safeClosingOdds = escapeHtml(bet.closingOdds || '');
+    const safeSportsbook = escapeHtml(bet.sportsbook || '');
     const safeNote = escapeHtml(bet.note || '');
 
     row.innerHTML = `
@@ -102,6 +104,7 @@ export function renderBets() {
       </td>
       <td>${safeBetType}</td>
       <td>${safeOdds}</td>
+      <td>${safeClosingOdds || '—'}</td>
       <td>$${parseFloat(bet.stake).toFixed(2)}</td>
       <td>$${parseFloat(bet.payout).toFixed(2)}</td>
       <td class="${profitClass}">
@@ -109,6 +112,7 @@ export function renderBets() {
       </td>
       <td>${formatDate(bet.date)}</td>
       <td>${safeSport}</td>
+      <td>${safeSportsbook || '—'}</td>
       <td class="note-cell">
         <div class="note-content" title="${safeNote}" onclick="showFullText(${JSON.stringify(bet.note || '')})">
           ${safeNote}

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,5 +1,67 @@
 import { exportToCSV, clearBets } from './bets.js';
 import { decodeToken } from './utils.js';
+import { API_BASE_URL } from './config.js';
+
+async function fetchProfile(token) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/users/me`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error('Failed to load profile');
+    return await res.json();
+  } catch (err) {
+    console.error('❌ Error fetching profile:', err.message);
+    return null;
+  }
+}
+
+async function saveOpenAiKey(token, apiKey) {
+  const res = await fetch(`${API_BASE_URL}/users/me/openai-key`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ apiKey })
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to save key');
+  }
+}
+
+async function removeOpenAiKey(token) {
+  const res = await fetch(`${API_BASE_URL}/users/me/openai-key`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  if (!res.ok) {
+    const error = await res.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to remove key');
+  }
+}
+
+function setAiKeyStatus(message, type = 'info') {
+  const el = document.getElementById('openai-key-status');
+  if (!el) return;
+  el.textContent = message;
+  el.dataset.state = type;
+}
+
+function updateAiKeyUI({ hasKey, setAt }) {
+  const removeBtn = document.getElementById('remove-openai-key');
+  const input = document.getElementById('openai-key');
+  if (!input) return;
+  if (hasKey) {
+    if (removeBtn) removeBtn.style.display = 'inline-block';
+    input.value = '';
+    const updated = setAt ? new Date(setAt).toLocaleString() : 'saved';
+    setAiKeyStatus(`Key stored securely (${updated}).`, 'success');
+  } else {
+    if (removeBtn) removeBtn.style.display = 'none';
+    setAiKeyStatus('No key on file. Paste your OpenAI key to enable the analyst.', 'info');
+  }
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   const exportBtn = document.getElementById('export-bets-btn');
@@ -30,5 +92,53 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (clearLink && token) {
     clearLink.style.display = 'block';
+  }
+
+  const aiForm = document.getElementById('openai-key-form');
+  const input = document.getElementById('openai-key');
+  const removeBtn = document.getElementById('remove-openai-key');
+
+  if (aiForm && input) {
+    if (!token) {
+      input.disabled = true;
+      setAiKeyStatus('Log in to manage your AI analyst key.', 'info');
+      aiForm.querySelector('button[type="submit"]').disabled = true;
+      if (removeBtn) removeBtn.style.display = 'none';
+      return;
+    }
+
+    fetchProfile(token).then(profile => {
+      updateAiKeyUI({ hasKey: Boolean(profile?.aiKeyConfigured), setAt: profile?.aiKeySetAt });
+    });
+
+    aiForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const apiKey = input.value.trim();
+      if (!apiKey) {
+        setAiKeyStatus('Enter a valid OpenAI API key (starts with sk-...).', 'error');
+        return;
+      }
+      try {
+        setAiKeyStatus('Saving key...', 'info');
+        await saveOpenAiKey(token, apiKey);
+        updateAiKeyUI({ hasKey: true, setAt: new Date().toISOString() });
+      } catch (err) {
+        console.error('❌ Error saving OpenAI key:', err.message);
+        setAiKeyStatus(err.message, 'error');
+      }
+    });
+
+    if (removeBtn) {
+      removeBtn.addEventListener('click', async () => {
+        try {
+          setAiKeyStatus('Removing key...', 'info');
+          await removeOpenAiKey(token);
+          updateAiKeyUI({ hasKey: false });
+        } catch (err) {
+          console.error('❌ Error removing OpenAI key:', err.message);
+          setAiKeyStatus(err.message, 'error');
+        }
+      });
+    }
   }
 });

--- a/settings.html
+++ b/settings.html
@@ -25,6 +25,20 @@
           <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
           <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
         </div>
+        <div class="ai-controls">
+          <h3>AI Analyst</h3>
+          <p class="muted">Provide your personal OpenAI API key to unlock the analyst. Keys are encrypted and stored server-side only.</p>
+          <form id="openai-key-form">
+            <label for="openai-key">OpenAI API Key</label>
+            <input type="password" id="openai-key" placeholder="sk-..." autocomplete="off" />
+            <div class="button-row">
+              <button type="submit" class="btn">Save Key</button>
+              <button type="button" class="btn btn-secondary" id="remove-openai-key" style="display: none;">Remove Key</button>
+            </div>
+            <p class="form-help">Never shared with the client after saving. Paste your key from the OpenAI dashboard.</p>
+          </form>
+          <p class="muted" id="openai-key-status"></p>
+        </div>
       </div>
     </div>
 

--- a/shared/header.html
+++ b/shared/header.html
@@ -2,11 +2,13 @@
   <nav class="top-nav">
     <div class="nav-icon-links">
       <div class="icon-btn"><a href="index.html" aria-label="Tracker">📋</a></div>
+      <div class="icon-btn"><a href="ai.html" aria-label="AI Analyst">🤖</a></div>
       <div class="icon-btn"><a href="profile.html" aria-label="Profile">👤</a></div>
     </div>
 
     <div class="nav-links">
       <a href="index.html">📋 Tracker</a>
+      <a href="ai.html">🤖 AI Analyst</a>
       <a href="profile.html">👤 Profile</a>
       <a href="settings.html">⚙️ Settings</a>
       <a href="admin.html">🛠️ Admin</a>

--- a/shared/stats-bar.html
+++ b/shared/stats-bar.html
@@ -5,6 +5,7 @@
   <div class="stat"><div class="stat-value" id="totalReturn">$0</div><div>Total Return</div></div>
   <div class="stat"><div class="stat-value" id="netProfit">$0</div><div>Net Profit/Loss</div></div>
   <div class="stat"><div class="stat-value" id="roi">0%</div><div>ROI</div></div>
+  <div class="stat"><div class="stat-value" id="clv">—</div><div>Avg CLV</div></div>
   <div class="stat"><div class="stat-value" id="bestSport">-</div><div>Most Profitable</div></div>
   <div class="stat"><div class="stat-value" id="avgStake">$0.00</div><div>Avg Stake</div></div>
   <div class="stat"><div class="stat-value" id="winStreak">0</div><div>Win Streak</div></div>

--- a/shared/table.html
+++ b/shared/table.html
@@ -7,11 +7,13 @@
         <th>Description</th>
         <th>Bet Type</th>
         <th>Odds</th>
+        <th>Closing Odds</th>
         <th>Stake</th>
         <th>Payout</th>
         <th>Profit/Loss</th>
         <th>Date</th>
         <th>Sport</th>
+        <th>Sportsbook</th>
         <th>Note</th>
       </tr>
     </thead>

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import cookieParser from 'cookie-parser';
 import authRouter from './routes/auth.js';
 import betRoutes from './routes/bets.js';
 import userRoutes from './routes/users.js';
+import aiRoutes from './routes/ai.js';
 import auth from './middleware/auth.js';
 import connectDB from './db.js';
 
@@ -52,6 +53,7 @@ await connectDB();
 app.use('/auth', authRouter);
 app.use('/bets', auth, betRoutes);
 app.use('/users', auth, userRoutes);
+app.use('/ai', auth, aiRoutes);
 
 // Health
 app.get('/health', (_, res) => res.json({ ok: true }));

--- a/src/models/Bet.js
+++ b/src/models/Bet.js
@@ -1,18 +1,23 @@
 import mongoose from 'mongoose';
 
-const BetSchema = new mongoose.Schema({
-  user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
-  date: String,
-  sport: String,
-  event: String,
-  betType: String,
-  odds: String,
-  stake: Number,
-  outcome: String,
-  payout: Number,
-  profitLoss: Number,
-  description: String,
-  note: String,
-});
+const BetSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    date: String,
+    sport: String,
+    event: String,
+    betType: String,
+    odds: String,
+    stake: Number,
+    outcome: String,
+    payout: Number,
+    profitLoss: Number,
+    description: String,
+    note: String,
+    sportsbook: String,
+    closingOdds: String,
+  },
+  { timestamps: true }
+);
 
 export default mongoose.model('Bet', BetSchema);

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -3,7 +3,9 @@ import mongoose from 'mongoose';
 const UserSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   password: { type: String, required: true },
-  role: { type: String, enum: ['user', 'admin'], default: 'user' }
+  role: { type: String, enum: ['user', 'admin'], default: 'user' },
+  openAiKey: { type: String, select: false, default: null },
+  openAiKeySetAt: { type: Date, default: null }
 });
 
 export default mongoose.model('User', UserSchema);

--- a/src/routes/ai.js
+++ b/src/routes/ai.js
@@ -1,0 +1,359 @@
+import { Router } from 'express';
+import Bet from '../models/Bet.js';
+import User from '../models/User.js';
+import { decrypt } from '../utils/crypto.js';
+import {
+  summarizeForModel,
+  computeUserStatsForClient,
+  selectBetsWithFilters,
+  buildFilterFacets,
+  formatDrawdown,
+} from '../utils/analysis.js';
+import logger from '../utils/logger.js';
+
+const router = Router();
+
+const DEFAULT_MODEL = process.env.AI_MODEL || 'gpt-4o-mini';
+
+function parseArrayParam(param) {
+  if (!param) return [];
+  if (Array.isArray(param)) {
+    return param.flatMap(value => String(value).split(',')).map(v => v.trim()).filter(Boolean);
+  }
+  return String(param)
+    .split(',')
+    .map(v => v.trim())
+    .filter(Boolean);
+}
+
+function normalizeFilters(filters = {}) {
+  const normalized = {};
+  if (filters.startDate) normalized.startDate = filters.startDate;
+  if (filters.endDate) normalized.endDate = filters.endDate;
+  if (filters.sports) {
+    normalized.sports = Array.isArray(filters.sports)
+      ? filters.sports.filter(Boolean)
+      : parseArrayParam(filters.sports);
+  }
+  if (filters.betTypes) {
+    normalized.betTypes = Array.isArray(filters.betTypes)
+      ? filters.betTypes.filter(Boolean)
+      : parseArrayParam(filters.betTypes);
+  }
+  if (filters.outcomes) {
+    normalized.outcomes = Array.isArray(filters.outcomes)
+      ? filters.outcomes.filter(Boolean)
+      : parseArrayParam(filters.outcomes);
+  }
+  return normalized;
+}
+
+async function fetchUserBets(userId) {
+  const bets = await Bet.find({ user: userId }).lean({ getters: true });
+  return bets;
+}
+
+router.get('/context', async (req, res) => {
+  try {
+    const filters = normalizeFilters(req.query || {});
+    const [user, allBets] = await Promise.all([
+      User.findById(req.user.id).select('openAiKey openAiKeySetAt username').lean({ getters: true }),
+      fetchUserBets(req.user.id),
+    ]);
+
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const scope = filters && Object.keys(filters).length ? 'filtered' : 'all';
+    const selectedBets = scope === 'filtered' ? selectBetsWithFilters(allBets, filters) : allBets;
+    const summary = summarizeForModel(selectedBets, { scope, filters });
+    const globalStats = computeUserStatsForClient(allBets);
+    const facets = buildFilterFacets(allBets);
+
+    res.json({
+      scope: summary.scope,
+      filters: summary.filtersApplied,
+      metrics: summary.metrics,
+      breakdowns: summary.breakdowns,
+      dataset: summary.dataset,
+      drawdown: formatDrawdown(summary.drawdown),
+      issues: summary.issues,
+      availableFilters: facets,
+      globalStats,
+      aiKeyConfigured: Boolean(user.openAiKey),
+      aiKeySetAt: user.openAiKeySetAt || null,
+      sampleSize: summary.sampleSize,
+      hasClosingOdds: summary.metrics.closingTracked > 0,
+    });
+  } catch (err) {
+    logger.error(err);
+    res.status(500).json({ error: 'Failed to prepare AI context' });
+  }
+});
+
+function buildSchema() {
+  return {
+    name: 'AiReply',
+    schema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string', description: 'Narrative response for the user. Use plain text.' },
+        metrics: {
+          type: 'object',
+          properties: {
+            totalBets: { type: 'integer' },
+            winRatePct: { type: ['number', 'null'] },
+            roiPct: { type: ['number', 'null'] },
+            netProfit: { type: ['number', 'null'] },
+            avgOdds: { type: ['number', 'null'] },
+            clvPct: { type: ['number', 'null'] },
+            longestWinStreak: { type: ['integer', 'null'] },
+            longestLossStreak: { type: ['integer', 'null'] },
+          },
+        },
+        breakdowns: {
+          type: 'object',
+          properties: {
+            bySport: {
+              type: 'object',
+              additionalProperties: {
+                type: 'object',
+                properties: {
+                  bets: { type: 'integer' },
+                  winRatePct: { type: ['number', 'null'] },
+                  roiPct: { type: ['number', 'null'] },
+                  netProfit: { type: ['number', 'null'] },
+                },
+              },
+            },
+            byMarket: {
+              type: 'object',
+              additionalProperties: {
+                type: 'object',
+                properties: {
+                  bets: { type: 'integer' },
+                  roiPct: { type: ['number', 'null'] },
+                  netProfit: { type: ['number', 'null'] },
+                },
+              },
+            },
+            byMonth: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  x: { type: ['string', 'number'] },
+                  y: { type: 'number' },
+                },
+                required: ['x', 'y'],
+              },
+            },
+          },
+        },
+        chart: {
+          type: ['object', 'null'],
+          properties: {
+            type: { type: 'string', enum: ['line', 'bar', 'area'] },
+            title: { type: 'string' },
+            yLabel: { type: ['string', 'null'] },
+            series: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                  points: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        x: { type: ['string', 'number'] },
+                        y: { type: 'number' },
+                      },
+                      required: ['x', 'y'],
+                    },
+                  },
+                },
+                required: ['name', 'points'],
+              },
+            },
+          },
+        },
+        followUps: {
+          type: 'array',
+          items: { type: 'string' },
+          minItems: 0,
+          maxItems: 5,
+        },
+      },
+      required: ['answer'],
+      additionalProperties: true,
+    },
+  };
+}
+
+function sendSse(res, event, data) {
+  res.write(`event: ${event}\n`);
+  const payload = typeof data === 'string' ? data : JSON.stringify(data);
+  res.write(`data: ${payload}\n\n`);
+}
+
+router.post('/analyze', async (req, res) => {
+  const { message, scope = 'all', filters = {}, history = [] } = req.body || {};
+
+  if (!message || typeof message !== 'string') {
+    return res.status(400).json({ error: 'A question is required.' });
+  }
+
+  try {
+    const normalizedFilters = normalizeFilters(filters);
+    const [user, allBets] = await Promise.all([
+      User.findById(req.user.id).select('+openAiKey openAiKeySetAt username').lean({ getters: true }),
+      fetchUserBets(req.user.id),
+    ]);
+
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    if (!user.openAiKey) {
+      return res.status(400).json({ error: 'OpenAI API key is not configured for this account.' });
+    }
+
+    const apiKey = decrypt(user.openAiKey);
+    if (!apiKey) {
+      return res.status(400).json({ error: 'Stored API key could not be decrypted. Please re-save it.' });
+    }
+
+    const dataScope = scope === 'filtered' ? 'filtered' : 'all';
+    const selectedBets = dataScope === 'filtered'
+      ? selectBetsWithFilters(allBets, normalizedFilters)
+      : allBets;
+
+    if (!selectedBets.length) {
+      return res.status(400).json({ error: 'No bets found for the selected scope/filters.' });
+    }
+
+    const summary = summarizeForModel(selectedBets, { scope: dataScope, filters: normalizedFilters });
+    const decided = summary.metrics.decidedBets || 0;
+    const tooSmall = decided < 3;
+
+    const systemPrompt = [
+      'You are the AI analyst for a sports betting tracker. The user will provide a data summary JSON containing their bets.',
+      'Use only the provided numbers. Do not invent data. Call out limitations when sample sizes are small.',
+      'When datasetTooSmall is true, highlight that insights may not be statistically significant and encourage broader analysis.',
+      'If issues are listed, acknowledge them in the answer.',
+      'Provide practical strategy suggestions grounded in the numbers and trends.',
+      'Always respond with JSON that follows the supplied schema.',
+      'Narrative should be concise but specific, referencing concrete values from the summary.',
+    ].join(' ');
+
+    const historyMessages = Array.isArray(history)
+      ? history.slice(-6).map(entry => ({
+          role: entry?.role === 'assistant' ? 'assistant' : 'user',
+          content: typeof entry?.content === 'string' ? entry.content : JSON.stringify(entry?.content || ''),
+        }))
+      : [];
+
+    const userContent = JSON.stringify({
+      question: message,
+      summary,
+      datasetTooSmall: tooSmall,
+    });
+
+    const body = {
+      model: DEFAULT_MODEL,
+      temperature: 0.2,
+      response_format: { type: 'json_schema', json_schema: buildSchema() },
+      messages: [
+        { role: 'system', content: systemPrompt },
+        ...historyMessages,
+        { role: 'user', content: userContent },
+      ],
+    };
+
+    const openAiResponse = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!openAiResponse.ok) {
+      const errorText = await openAiResponse.text();
+      logger.error('OpenAI error:', errorText);
+      return res.status(502).json({ error: 'Failed to generate AI analysis.' });
+    }
+
+    const completion = await openAiResponse.json();
+    const rawContent = completion?.choices?.[0]?.message?.content;
+    let aiReply;
+    try {
+      aiReply = rawContent ? JSON.parse(rawContent) : { answer: '' };
+    } catch (err) {
+      logger.error('Failed to parse AI response', err);
+      aiReply = { answer: rawContent || '' };
+    }
+
+    const metrics = {
+      totalBets: summary.metrics.totalBets,
+      winRatePct: summary.metrics.winRatePct,
+      roiPct: summary.metrics.roiPct,
+      netProfit: summary.metrics.netProfit,
+      avgOdds: summary.metrics.avgOdds,
+      clvPct: summary.metrics.clvPct,
+      longestWinStreak: summary.metrics.longestWinStreak,
+      longestLossStreak: summary.metrics.longestLossStreak,
+    };
+
+    const finalPayload = {
+      answer: aiReply?.answer || '',
+      metrics,
+      breakdowns: {
+        bySport: summary.breakdowns.bySport,
+        byMarket: summary.breakdowns.byMarket,
+        byMonth: summary.breakdowns.byMonth,
+      },
+      chart: aiReply?.chart || null,
+      followUps: Array.isArray(aiReply?.followUps) ? aiReply.followUps.slice(0, 5) : [],
+      context: {
+        scope: summary.scope,
+        filters: summary.filtersApplied,
+        dataset: summary.dataset,
+        drawdown: formatDrawdown(summary.drawdown),
+        issues: summary.issues,
+      },
+    };
+
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache, no-transform');
+    res.setHeader('Connection', 'keep-alive');
+    if (typeof res.flushHeaders === 'function') {
+      res.flushHeaders();
+    }
+
+    const tokens = finalPayload.answer ? finalPayload.answer.match(/(\S+|\s+)/g) : [];
+    if (tokens) {
+      for (const token of tokens) {
+        sendSse(res, 'token', token);
+      }
+    }
+
+    sendSse(res, 'payload', finalPayload);
+    sendSse(res, 'end', 'done');
+    res.end();
+  } catch (err) {
+    logger.error(err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Failed to generate AI analysis.' });
+    } else {
+      sendSse(res, 'error', { message: 'An unexpected error occurred.' });
+      res.end();
+    }
+  }
+});
+
+export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,6 +1,9 @@
 import { Router } from 'express';
 import User from '../models/User.js';
+import Bet from '../models/Bet.js';
 import authorize from '../middleware/authorize.js';
+import { encrypt } from '../utils/crypto.js';
+import { computeUserStatsForClient } from '../utils/analysis.js';
 
 const router = Router();
 
@@ -8,6 +11,61 @@ router.get('/', authorize('admin'), async (req, res) => {
   try {
     const users = await User.find().select('username');
     res.json(users);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/me', async (req, res) => {
+  try {
+    const [user, bets] = await Promise.all([
+      User.findById(req.user.id).select('username role openAiKeySetAt openAiKey').lean({ getters: true }),
+      Bet.find({ user: req.user.id }).lean({ getters: true }),
+    ]);
+
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+
+    const stats = computeUserStatsForClient(bets);
+    res.json({
+      username: user.username,
+      role: user.role,
+      stats,
+      aiKeyConfigured: Boolean(user.openAiKey),
+      aiKeySetAt: user.openAiKeySetAt || null,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/me/openai-key', async (req, res) => {
+  try {
+    const { apiKey } = req.body;
+    if (!apiKey || typeof apiKey !== 'string' || apiKey.trim().length < 10) {
+      return res.status(400).json({ error: 'A valid OpenAI API key is required.' });
+    }
+
+    const encrypted = encrypt(apiKey.trim());
+    await User.findByIdAndUpdate(req.user.id, {
+      openAiKey: encrypted,
+      openAiKeySetAt: new Date(),
+    });
+
+    res.status(204).end();
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.delete('/me/openai-key', async (req, res) => {
+  try {
+    await User.findByIdAndUpdate(req.user.id, {
+      openAiKey: null,
+      openAiKeySetAt: null,
+    });
+    res.status(204).end();
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -1,0 +1,449 @@
+const DECIDED_OUTCOMES = new Set(['Win', 'Loss']);
+const RESOLVED_OUTCOMES = new Set(['Win', 'Loss', 'Push']);
+
+function toNumber(value) {
+  if (value === undefined || value === null) return null;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  const str = String(value).trim();
+  if (!str) return null;
+  const normalized = str.replace(/[^0-9+\-\.]/g, '');
+  if (!normalized) return null;
+  const num = Number(normalized);
+  return Number.isFinite(num) ? num : null;
+}
+
+function isLikelyDecimal(raw, numeric) {
+  if (raw === undefined || raw === null) return false;
+  const str = String(raw).trim();
+  if (!str) return false;
+  if (str.includes('/')) return false; // fraction odds not supported yet
+  if (str.includes('.')) return true;
+  if (!str.startsWith('+') && !str.startsWith('-') && Math.abs(numeric) < 100) return true;
+  return false;
+}
+
+function toDecimalOdds(raw) {
+  const numeric = toNumber(raw);
+  if (numeric === null) return null;
+  if (isLikelyDecimal(raw, numeric)) {
+    return numeric > 0 ? numeric : null;
+  }
+  if (numeric > 0) {
+    return 1 + numeric / 100;
+  }
+  if (numeric < 0) {
+    return 1 + 100 / Math.abs(numeric);
+  }
+  return null;
+}
+
+function toImpliedProbability(raw) {
+  const numeric = toNumber(raw);
+  if (numeric === null) return null;
+  if (isLikelyDecimal(raw, numeric)) {
+    return numeric > 0 ? 1 / numeric : null;
+  }
+  if (numeric > 0) {
+    return 100 / (numeric + 100);
+  }
+  if (numeric < 0) {
+    return Math.abs(numeric) / (Math.abs(numeric) + 100);
+  }
+  return null;
+}
+
+function asDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toPlainBet(doc) {
+  const raw = typeof doc?.toObject === 'function' ? doc.toObject() : { ...doc };
+  const date = asDate(raw.date);
+  const stake = Number(raw.stake) || 0;
+  const payout = Number(raw.payout) || 0;
+  let profitLoss = Number(raw.profitLoss);
+  if (!Number.isFinite(profitLoss)) {
+    if (raw.outcome === 'Pending') {
+      profitLoss = 0;
+    } else if (raw.outcome && RESOLVED_OUTCOMES.has(raw.outcome)) {
+      profitLoss = payout - stake;
+    } else {
+      profitLoss = 0;
+    }
+  }
+  return {
+    ...raw,
+    date,
+    stake,
+    payout,
+    profitLoss,
+    oddsValue: toNumber(raw.odds),
+    closingOddsValue: toNumber(raw.closingOdds),
+    impliedProb: toImpliedProbability(raw.odds),
+    closingImpliedProb: toImpliedProbability(raw.closingOdds),
+  };
+}
+
+function round(value, decimals = 2) {
+  if (!Number.isFinite(value)) return null;
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function sortChronologically(bets) {
+  return [...bets].sort((a, b) => {
+    const aTime = a.date ? a.date.getTime() : 0;
+    const bTime = b.date ? b.date.getTime() : 0;
+    if (aTime === bTime) {
+      return (a._id || '').toString().localeCompare((b._id || '').toString());
+    }
+    return aTime - bTime;
+  });
+}
+
+function computeStreaks(bets) {
+  const chronological = sortChronologically(bets);
+  let currentWin = 0;
+  let currentLoss = 0;
+  let maxWin = 0;
+  let maxLoss = 0;
+  for (const bet of chronological) {
+    if (bet.outcome === 'Win') {
+      currentWin += 1;
+      maxWin = Math.max(maxWin, currentWin);
+      currentLoss = 0;
+    } else if (bet.outcome === 'Loss') {
+      currentLoss += 1;
+      maxLoss = Math.max(maxLoss, currentLoss);
+      currentWin = 0;
+    }
+  }
+  return { longestWinStreak: maxWin, longestLossStreak: maxLoss };
+}
+
+function computeDrawdown(bets) {
+  const chronological = sortChronologically(bets).filter(b => DECIDED_OUTCOMES.has(b.outcome));
+  let peak = 0;
+  let peakDate = null;
+  let equity = 0;
+  let worst = { amount: 0, start: null, end: null };
+  for (const bet of chronological) {
+    equity += Number(bet.profitLoss) || 0;
+    if (equity > peak) {
+      peak = equity;
+      peakDate = bet.date || peakDate;
+    }
+    const drawdown = peak - equity;
+    if (drawdown > worst.amount) {
+      worst = {
+        amount: drawdown,
+        start: peakDate,
+        end: bet.date || peakDate,
+      };
+    }
+  }
+  const durationMs = worst.start && worst.end ? Math.max(0, worst.end - worst.start) : 0;
+  const durationDays = durationMs ? Math.round(durationMs / (1000 * 60 * 60 * 24)) : 0;
+  return {
+    amount: round(worst.amount, 2) || 0,
+    start: worst.start || null,
+    end: worst.end || null,
+    durationDays,
+  };
+}
+
+function computeBreakdowns(bets) {
+  const resolved = bets.filter(b => RESOLVED_OUTCOMES.has(b.outcome));
+  const bySport = {};
+  const byMarket = {};
+  const byMonthMap = new Map();
+
+  for (const bet of resolved) {
+    const sportKey = bet.sport || 'Unspecified';
+    const sportEntry = bySport[sportKey] || { bets: 0, wins: 0, stake: 0, payout: 0, profit: 0 };
+    sportEntry.bets += 1;
+    sportEntry.stake += bet.stake || 0;
+    sportEntry.payout += bet.payout || 0;
+    sportEntry.profit += bet.profitLoss || 0;
+    if (bet.outcome === 'Win') sportEntry.wins += 1;
+    bySport[sportKey] = sportEntry;
+
+    const marketKey = bet.betType || 'Other';
+    const marketEntry = byMarket[marketKey] || { bets: 0, stake: 0, profit: 0 };
+    marketEntry.bets += 1;
+    marketEntry.stake += bet.stake || 0;
+    marketEntry.profit += bet.profitLoss || 0;
+    byMarket[marketKey] = marketEntry;
+
+    if (bet.date) {
+      const monthKey = `${bet.date.getUTCFullYear()}-${String(bet.date.getUTCMonth() + 1).padStart(2, '0')}`;
+      const monthEntry = byMonthMap.get(monthKey) || 0;
+      byMonthMap.set(monthKey, monthEntry + (bet.profitLoss || 0));
+    }
+  }
+
+  const bySportFormatted = Object.fromEntries(
+    Object.entries(bySport).map(([sport, entry]) => {
+      const winRate = entry.bets ? (entry.wins / entry.bets) * 100 : null;
+      const roi = entry.stake > 0 ? (entry.profit / entry.stake) * 100 : null;
+      return [sport, {
+        bets: entry.bets,
+        winRatePct: winRate !== null ? round(winRate, 2) : null,
+        roiPct: roi !== null ? round(roi, 2) : null,
+        netProfit: round(entry.profit, 2) || 0,
+      }];
+    })
+  );
+
+  const byMarketFormatted = Object.fromEntries(
+    Object.entries(byMarket).map(([market, entry]) => {
+      const roi = entry.stake > 0 ? (entry.profit / entry.stake) * 100 : null;
+      return [market, {
+        bets: entry.bets,
+        roiPct: roi !== null ? round(roi, 2) : null,
+        netProfit: round(entry.profit, 2) || 0,
+      }];
+    })
+  );
+
+  const byMonth = Array.from(byMonthMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([month, profit]) => ({ x: month, y: round(profit, 2) || 0 }));
+
+  return { bySport: bySportFormatted, byMarket: byMarketFormatted, byMonth };
+}
+
+function detectIssues(bets) {
+  const issues = new Set();
+  for (const bet of bets) {
+    if ((bet.stake || 0) < 0) {
+      issues.add('Negative stake values detected.');
+    }
+    if (RESOLVED_OUTCOMES.has(bet.outcome)) {
+      if (bet.payout === undefined || bet.payout === null) {
+        issues.add('Some settled bets are missing payout values.');
+      }
+      if (bet.profitLoss === undefined || bet.profitLoss === null) {
+        issues.add('Some settled bets are missing profit/loss values.');
+      }
+    }
+    if (bet.outcome === 'Pending' && (bet.payout || 0) !== 0) {
+      issues.add('Pending bets should not have payouts recorded yet.');
+    }
+  }
+  return Array.from(issues);
+}
+
+function computeMetrics(bets) {
+  const totalBets = bets.length;
+  const resolved = bets.filter(b => RESOLVED_OUTCOMES.has(b.outcome));
+  const decided = resolved.filter(b => DECIDED_OUTCOMES.has(b.outcome));
+  const wins = decided.filter(b => b.outcome === 'Win');
+  const losses = decided.filter(b => b.outcome === 'Loss');
+
+  const totalStake = resolved.reduce((sum, bet) => sum + (bet.stake || 0), 0);
+  const totalPayout = resolved.reduce((sum, bet) => sum + (bet.payout || 0), 0);
+  const netProfit = totalPayout - totalStake;
+  const winRate = decided.length ? (wins.length / decided.length) * 100 : null;
+  const roi = totalStake > 0 ? (netProfit / totalStake) * 100 : null;
+
+  const decimalOdds = decided
+    .map(bet => toDecimalOdds(bet.odds))
+    .filter(value => Number.isFinite(value) && value > 0);
+  const avgDecimalOdds = decimalOdds.length
+    ? decimalOdds.reduce((sum, value) => sum + value, 0) / decimalOdds.length
+    : null;
+
+  const clvEntries = bets
+    .map(bet => {
+      if (!Number.isFinite(bet.impliedProb) || !Number.isFinite(bet.closingImpliedProb)) {
+        return null;
+      }
+      return (bet.closingImpliedProb - bet.impliedProb) * 100;
+    })
+    .filter(value => value !== null);
+  const clvPct = clvEntries.length
+    ? clvEntries.reduce((sum, value) => sum + value, 0) / clvEntries.length
+    : null;
+
+  const pendingExposure = bets
+    .filter(bet => bet.outcome === 'Pending')
+    .reduce((sum, bet) => sum + (bet.stake || 0), 0);
+
+  const { longestWinStreak, longestLossStreak } = computeStreaks(bets);
+  const drawdown = computeDrawdown(bets);
+
+  const closingTracked = bets.filter(bet => Number.isFinite(bet.closingImpliedProb) && Number.isFinite(bet.impliedProb));
+  const closingCoveragePct = totalBets ? (closingTracked.length / totalBets) * 100 : 0;
+
+  return {
+    totalBets,
+    winRatePct: winRate !== null ? round(winRate, 2) : null,
+    roiPct: roi !== null ? round(roi, 2) : null,
+    netProfit: round(netProfit, 2) || 0,
+    avgOdds: avgDecimalOdds !== null ? round(avgDecimalOdds, 2) : null,
+    clvPct: clvPct !== null ? round(clvPct, 2) : null,
+    longestWinStreak,
+    longestLossStreak,
+    pendingExposure: round(pendingExposure, 2) || 0,
+    decidedBets: decided.length,
+    resolvedBets: resolved.length,
+    wins: wins.length,
+    losses: losses.length,
+    totalStake: round(totalStake, 2) || 0,
+    totalPayout: round(totalPayout, 2) || 0,
+    closingTracked: closingTracked.length,
+    closingCoveragePct: round(closingCoveragePct, 2) || 0,
+    drawdown,
+  };
+}
+
+export function buildFilterFacets(bets) {
+  const sports = new Set();
+  const betTypes = new Set();
+  const outcomes = new Set();
+  for (const bet of bets) {
+    if (bet.sport) sports.add(bet.sport);
+    if (bet.betType) betTypes.add(bet.betType);
+    if (bet.outcome) outcomes.add(bet.outcome);
+  }
+  return {
+    sports: Array.from(sports).sort((a, b) => a.localeCompare(b)),
+    betTypes: Array.from(betTypes).sort((a, b) => a.localeCompare(b)),
+    outcomes: Array.from(outcomes).sort((a, b) => a.localeCompare(b)),
+  };
+}
+
+function sanitizeFilters(filters = {}) {
+  const clean = {};
+  if (filters.startDate) clean.startDate = filters.startDate;
+  if (filters.endDate) clean.endDate = filters.endDate;
+  if (filters.sports?.length) clean.sports = [...filters.sports];
+  if (filters.betTypes?.length) clean.betTypes = [...filters.betTypes];
+  if (filters.outcomes?.length) clean.outcomes = [...filters.outcomes];
+  return clean;
+}
+
+function formatSampleBet(bet) {
+  return {
+    date: bet.date ? bet.date.toISOString().split('T')[0] : null,
+    sport: bet.sport || null,
+    market: bet.betType || null,
+    selection: bet.description || null,
+    outcome: bet.outcome || null,
+    odds: bet.odds || null,
+    closingOdds: bet.closingOdds || null,
+    stake: bet.stake,
+    payout: bet.payout,
+    profitLoss: bet.profitLoss,
+    note: bet.note || null,
+    sportsbook: bet.sportsbook || null,
+  };
+}
+
+export function summarizeForModel(rawBets, { scope = 'all', filters = {} } = {}) {
+  const bets = rawBets.map(toPlainBet);
+  const chronological = sortChronologically(bets);
+  const metrics = computeMetrics(chronological);
+  const breakdowns = computeBreakdowns(chronological);
+  const issues = detectIssues(chronological);
+  const facets = buildFilterFacets(chronological);
+
+  const sampleLimit = chronological.length > 200 ? 80 : 150;
+  const condensedSample = chronological.length > sampleLimit
+    ? chronological.slice(-sampleLimit)
+    : chronological;
+
+  const firstBet = chronological[0];
+  const lastBet = chronological[chronological.length - 1];
+
+  const summary = {
+    scope,
+    filtersApplied: sanitizeFilters(filters),
+    metrics,
+    breakdowns,
+    issues,
+    dataset: {
+      totalBets: metrics.totalBets,
+      resolvedBets: metrics.resolvedBets,
+      decidedBets: metrics.decidedBets,
+      wins: metrics.wins,
+      losses: metrics.losses,
+      pendingBets: metrics.totalBets - metrics.resolvedBets,
+      totalStake: metrics.totalStake,
+      totalPayout: metrics.totalPayout,
+      pendingExposure: metrics.pendingExposure,
+      closingTracked: metrics.closingTracked,
+      closingCoveragePct: metrics.closingCoveragePct,
+      firstBetDate: firstBet?.date ? firstBet.date.toISOString() : null,
+      lastBetDate: lastBet?.date ? lastBet.date.toISOString() : null,
+    },
+    drawdown: metrics.drawdown,
+    sampleSize: condensedSample.length,
+    sampleBets: condensedSample.map(formatSampleBet),
+    availableFilters: facets,
+  };
+
+  return summary;
+}
+
+export function computeUserStatsForClient(rawBets) {
+  const bets = rawBets.map(toPlainBet);
+  const chronological = sortChronologically(bets);
+  const metrics = computeMetrics(chronological);
+  const bestSport = (() => {
+    const { bySport } = computeBreakdowns(chronological);
+    let top = null;
+    for (const [sport, entry] of Object.entries(bySport)) {
+      if (top === null || (entry.netProfit || 0) > (top.netProfit || 0)) {
+        top = { sport, ...entry };
+      }
+    }
+    return top;
+  })();
+
+  return {
+    totalBets: metrics.totalBets,
+    winRate: metrics.winRatePct || 0,
+    roi: metrics.roiPct || 0,
+    totalStaked: metrics.totalStake,
+    totalReturn: metrics.totalPayout,
+    netProfit: metrics.netProfit,
+    mostProfitable: bestSport?.sport || '-',
+    avgStake: metrics.resolvedBets ? round(metrics.totalStake / metrics.resolvedBets, 2) || 0 : 0,
+    winStreak: metrics.longestWinStreak || 0,
+    clv: metrics.clvPct,
+    pendingExposure: metrics.pendingExposure,
+  };
+}
+
+export function selectBetsWithFilters(rawBets, filters = {}) {
+  const bets = rawBets.map(toPlainBet);
+  const { startDate, endDate, sports, betTypes, outcomes } = filters;
+  const start = startDate ? new Date(startDate) : null;
+  const end = endDate ? new Date(endDate) : null;
+  const sportSet = sports?.length ? new Set(sports) : null;
+  const betTypeSet = betTypes?.length ? new Set(betTypes) : null;
+  const outcomeSet = outcomes?.length ? new Set(outcomes) : null;
+
+  return bets.filter(bet => {
+    if (start && bet.date && bet.date < start) return false;
+    if (end && bet.date && bet.date > end) return false;
+    if (sportSet && bet.sport && !sportSet.has(bet.sport)) return false;
+    if (betTypeSet && bet.betType && !betTypeSet.has(bet.betType)) return false;
+    if (outcomeSet && bet.outcome && !outcomeSet.has(bet.outcome)) return false;
+    return true;
+  });
+}
+
+export function formatDrawdown(drawdown) {
+  if (!drawdown?.amount) return null;
+  return {
+    amount: drawdown.amount,
+    start: drawdown.start ? drawdown.start.toISOString() : null,
+    end: drawdown.end ? drawdown.end.toISOString() : null,
+    durationDays: drawdown.durationDays,
+  };
+}

--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -1,0 +1,33 @@
+import crypto from 'crypto';
+
+const DEFAULT_SECRET = process.env.AI_KEY_SECRET || process.env.JWT_SECRET;
+
+function getSecretKey() {
+  if (!DEFAULT_SECRET) {
+    throw new Error('AI_KEY_SECRET (or JWT_SECRET) must be set to store API keys securely');
+  }
+  return crypto.createHash('sha256').update(DEFAULT_SECRET).digest();
+}
+
+export function encrypt(text) {
+  if (!text) return null;
+  const key = getSecretKey();
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString('base64');
+}
+
+export function decrypt(payload) {
+  if (!payload) return null;
+  const key = getSecretKey();
+  const raw = Buffer.from(payload, 'base64');
+  const iv = raw.subarray(0, 12);
+  const tag = raw.subarray(12, 28);
+  const data = raw.subarray(28);
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(data), decipher.final()]);
+  return decrypted.toString('utf8');
+}


### PR DESCRIPTION
## Summary
- add an AI Analyst page with a streaming chat UI, contextual metrics, filter controls, and chart rendering
- extend bet records with sportsbook and closing odds support, surface CLV in stats, and update shared components
- create secure OpenAI key storage plus AI analysis endpoints that summarize user bets, stream responses, and expose context APIs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb042a29c8323a412004e51c9b1bc