### PR TITLE
Fix Express preflight wildcard routes

### DIFF
--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -45,7 +45,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 
 // Handle preflight requests early so they don't hit auth
-app.options('*', cors(corsOptions));
+app.options('/:path(*)', cors(corsOptions));
 
 // Debug logging
 app.use((req, res, next) => {

--- a/src/app.js
+++ b/src/app.js
@@ -45,7 +45,7 @@ app.use(cors({
 }));
 
 // Optional: explicit preflight handler (helps some proxies)
-app.options('*', cors());
+app.options('/:path(*)', cors());
 
 await connectDB();
 


### PR DESCRIPTION
## Summary
- replace legacy wildcard preflight handler in the standalone backend with an Express 5 compatible named parameter route
- adjust the serverless app entry point to use the same named wildcard parameter for OPTIONS preflight handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf877e0b3c8323a3f458f83be1b1f3