### PR TITLE
Fix settings auth buttons for logged-in users

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -58,7 +58,7 @@ function updateAiKeyUI({ hasKey, setAt }) {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const exportBtn = document.getElementById('export-bets-btn');
   if (exportBtn) {
     exportBtn.addEventListener('click', exportToCSV);


### PR DESCRIPTION
## Summary
- mark the Settings DOMContentLoaded handler as async so profile data can be awaited
- ensure logged-in users have the correct auth controls displayed once their profile loads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d08ea50cec8323946417cfd41e785f