### PR TITLE
Add rewrite for AI API routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "rewrites": [
     { "source": "/api/bets/:path*", "destination": "https://betting-tracker-backend.vercel.app/api/bets/:path*" },
     { "source": "/api/users/:path*", "destination": "https://betting-tracker-backend.vercel.app/api/users/:path*" },
-    { "source": "/api/auth/:path*", "destination": "https://betting-tracker-backend.vercel.app/api/auth/:path*" }
+    { "source": "/api/auth/:path*", "destination": "https://betting-tracker-backend.vercel.app/api/auth/:path*" },
+    { "source": "/api/ai/:path*", "destination": "https://betting-tracker-backend.vercel.app/api/ai/:path*" }
   ]
 }


### PR DESCRIPTION
## Summary
- add a Vercel rewrite so /api/ai requests are forwarded to the backend service

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d0a2223af8832390cab583a2d7f018