### PR TITLE
Show AI analyst equity curve

### DIFF
--- a/betting-tracker-backend/routes/ai.js
+++ b/betting-tracker-backend/routes/ai.js
@@ -152,6 +152,17 @@ function buildSchema() {
                 required: ['x', 'y'],
               },
             },
+            equityCurve: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  x: { type: ['string', 'number'] },
+                  y: { type: 'number' },
+                },
+                required: ['x', 'y'],
+              },
+            },
           },
         },
         chart: {

--- a/betting-tracker-backend/utils/analysis.js
+++ b/betting-tracker-backend/utils/analysis.js
@@ -163,6 +163,9 @@ function computeBreakdowns(bets) {
   const bySport = {};
   const byMarket = {};
   const byMonthMap = new Map();
+  const equityCurve = [];
+  let runningNet = 0;
+  let resolvedIndex = 0;
 
   for (const bet of resolved) {
     const sportKey = bet.sport || 'Unspecified';
@@ -186,6 +189,13 @@ function computeBreakdowns(bets) {
       const monthEntry = byMonthMap.get(monthKey) || 0;
       byMonthMap.set(monthKey, monthEntry + (bet.profitLoss || 0));
     }
+
+    runningNet += bet.profitLoss || 0;
+    const label = bet.date
+      ? bet.date.toISOString().slice(0, 10)
+      : `Bet ${resolvedIndex + 1}`;
+    equityCurve.push({ x: label, y: round(runningNet, 2) || 0 });
+    resolvedIndex += 1;
   }
 
   const bySportFormatted = Object.fromEntries(
@@ -216,7 +226,7 @@ function computeBreakdowns(bets) {
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([month, profit]) => ({ x: month, y: round(profit, 2) || 0 }));
 
-  return { bySport: bySportFormatted, byMarket: byMarketFormatted, byMonth };
+  return { bySport: bySportFormatted, byMarket: byMarketFormatted, byMonth, equityCurve };
 }
 
 function detectIssues(bets) {

--- a/src/routes/ai.js
+++ b/src/routes/ai.js
@@ -152,6 +152,17 @@ function buildSchema() {
                 required: ['x', 'y'],
               },
             },
+            equityCurve: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  x: { type: ['string', 'number'] },
+                  y: { type: 'number' },
+                },
+                required: ['x', 'y'],
+              },
+            },
           },
         },
         chart: {

--- a/src/utils/analysis.js
+++ b/src/utils/analysis.js
@@ -159,6 +159,9 @@ function computeBreakdowns(bets) {
   const bySport = {};
   const byMarket = {};
   const byMonthMap = new Map();
+  const equityCurve = [];
+  let runningNet = 0;
+  let resolvedIndex = 0;
 
   for (const bet of resolved) {
     const sportKey = bet.sport || 'Unspecified';
@@ -182,6 +185,13 @@ function computeBreakdowns(bets) {
       const monthEntry = byMonthMap.get(monthKey) || 0;
       byMonthMap.set(monthKey, monthEntry + (bet.profitLoss || 0));
     }
+
+    runningNet += bet.profitLoss || 0;
+    const label = bet.date
+      ? bet.date.toISOString().slice(0, 10)
+      : `Bet ${resolvedIndex + 1}`;
+    equityCurve.push({ x: label, y: round(runningNet, 2) || 0 });
+    resolvedIndex += 1;
   }
 
   const bySportFormatted = Object.fromEntries(
@@ -212,7 +222,7 @@ function computeBreakdowns(bets) {
     .sort(([a], [b]) => a.localeCompare(b))
     .map(([month, profit]) => ({ x: month, y: round(profit, 2) || 0 }));
 
-  return { bySport: bySportFormatted, byMarket: byMarketFormatted, byMonth };
+  return { bySport: bySportFormatted, byMarket: byMarketFormatted, byMonth, equityCurve };
 }
 
 function detectIssues(bets) {


### PR DESCRIPTION
## Summary
- compute a cumulative net profit/loss equity curve when preparing AI analysis context
- expose the equity curve in the AI response schema for both runtime paths
- render the AI analyst chart using the equity curve data with a clearer caption

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2c74d33a083238162b73a1c776681