### PR TITLE
Swap snapshot and breakdown panels in AI analyst sidebar

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -56,9 +56,8 @@
 
       <aside class="ai-context" aria-label="Analysis context">
         <div class="context-card">
-          <h2>Snapshot</h2>
-          <div class="context-metrics" id="context-metrics"></div>
-          <div class="context-extra" id="context-extra"></div>
+          <h3>Breakdowns</h3>
+          <div class="context-breakdowns" id="context-breakdowns"></div>
         </div>
         <div class="context-card">
           <h3>Chart</h3>
@@ -66,8 +65,9 @@
           <p class="chart-caption" id="chart-caption"></p>
         </div>
         <div class="context-card">
-          <h3>Breakdowns</h3>
-          <div class="context-breakdowns" id="context-breakdowns"></div>
+          <h2>Snapshot</h2>
+          <div class="context-metrics" id="context-metrics"></div>
+          <div class="context-extra" id="context-extra"></div>
         </div>
         <div class="context-card">
           <h3>Follow-up ideas</h3>


### PR DESCRIPTION
## Summary
- reorder the AI analyst sidebar context cards so the breakdowns panel appears before the snapshot panel

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e158b55f088323ae03112ef4b29f06