### PR TITLE
Add client-side pagination to bet history table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -294,6 +294,68 @@ body {
   overflow-y: auto;
 }
 
+.table-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+.pagination-page-size {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #2c3e50;
+}
+
+.pagination-page-size label {
+  font-weight: 600;
+}
+
+.pagination-page-size select {
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid #d0d7de;
+  background-color: #fff;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.pagination-summary {
+  flex: 1;
+  min-width: 160px;
+  font-size: 13px;
+  color: #606f7b;
+}
+
+.pagination-buttons {
+  display: flex;
+  gap: 6px;
+}
+
+.pagination-buttons button {
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid #d0d7de;
+  background-color: #fff;
+  cursor: pointer;
+  font-size: 14px;
+  color: #2c3e50;
+  transition: background-color 0.2s ease;
+}
+
+.pagination-buttons button:hover:not(:disabled) {
+  background-color: #ecf0f1;
+}
+
+.pagination-buttons button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -355,6 +417,12 @@ td {
 
   td {
     padding: 18px 05px;
+  }
+}
+
+@media (max-width: 768px) {
+  .pagination-summary {
+    order: 3;
   }
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,6 @@
 import { bets, fetchBets, loadDemoData as loadDemoBets, exportToCSV } from './bets.js';
 import { initForm, handleAddBet, saveFormData, startEditBet } from './form.js';
-import { renderBets, handleRemoveBet, handleSettleBet, showTableLoading } from './render.js';
+import { renderBets, handleRemoveBet, handleSettleBet, showTableLoading, resetPagination } from './render.js';
 import { updateStats } from './stats.js';
 import { showFullText, closeModal, showLearnMore } from './modal.js';
 
@@ -10,6 +10,7 @@ window.startEditBet = startEditBet;
 window.removeBet = handleRemoveBet;
 window.loadDemoData = async () => {
   loadDemoBets();
+  resetPagination();
   renderBets();
   await updateStats();
 };
@@ -37,6 +38,7 @@ initForm();
       await fetchBets();
     }
 
+    resetPagination();
     renderBets();
     await updateStats();
   });

--- a/js/form.js
+++ b/js/form.js
@@ -1,5 +1,5 @@
 import { addBet as addBetData, calculatePayout, updateBet as updateBetData, bets } from './bets.js';
-import { renderBets } from './render.js';
+import { renderBets, resetPagination } from './render.js';
 import { updateStats } from './stats.js';
 
 const FORM_FIELDS = ['date', 'sport', 'event', 'betType', 'odds', 'stake', 'outcome', 'description', 'note', 'closingOdds', 'sportsbook'];
@@ -140,6 +140,7 @@ export async function handleAddBet() {
     } else {
       bet.id = Date.now();
       await addBetData(bet);
+      resetPagination();
     }
     renderBets();
     await updateStats();

--- a/shared/table.html
+++ b/shared/table.html
@@ -22,3 +22,24 @@
     </tbody>
   </table>
 </div>
+
+<div class="table-pagination" aria-live="polite">
+  <div class="pagination-page-size">
+    <label for="pageSize">Rows per page</label>
+    <select id="pageSize">
+      <option value="25">25</option>
+      <option value="50">50</option>
+      <option value="100">100</option>
+      <option value="250">250</option>
+    </select>
+  </div>
+
+  <div id="paginationSummary" class="pagination-summary">No bets to display</div>
+
+  <div class="pagination-buttons" role="group" aria-label="Pagination controls">
+    <button type="button" id="paginationFirst" aria-label="First page">«</button>
+    <button type="button" id="paginationPrev" aria-label="Previous page">‹</button>
+    <button type="button" id="paginationNext" aria-label="Next page">›</button>
+    <button type="button" id="paginationLast" aria-label="Last page">»</button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- add client-side pagination controls to the bet history table to avoid re-rendering the entire list
- manage pagination state in the renderer and reset when loading new data or adding bets
- style the pagination controls to match the existing table design

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e17550e5cc8323a66ea72cac090562