### PR TITLE
Remove stats bar from AI analyst page

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -9,8 +9,6 @@
 <body>
   <div class="container ai-page">
     <div id="include-header"></div>
-    <div id="include-stats"></div>
-
     <div class="ai-layout" id="ai-layout">
       <section class="ai-chat" aria-label="AI analyst conversation">
         <div class="ai-thread" id="ai-thread"></div>


### PR DESCRIPTION
## Summary
- stop rendering the shared stats bar include on the AI analyst page so the layout only shows the AI tools

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e18e6614048323924ba550dadfdb40