### PR TITLE
Rename AI analyst page to Data

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>AI Analyst</title>
+  <title>Data</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
   <div class="container ai-page">
     <div id="include-header"></div>
     <div class="ai-layout" id="ai-layout">
-      <section class="ai-chat" aria-label="AI analyst conversation">
+      <section class="ai-chat" aria-label="Data analysis conversation">
         <div class="ai-thread" id="ai-thread"></div>
         <div class="ai-input" id="ai-input">
           <div class="scope-selector" role="group" aria-label="Analysis scope">
@@ -83,8 +83,8 @@
       const title = document.getElementById('page-title');
       const subtitle = document.getElementById('page-subtitle');
       const learnMore = document.getElementById('learn-more-link');
-      if (title) title.textContent = '🤖 AI Analyst';
-      if (subtitle) subtitle.textContent = 'Chat with your betting data specialist';
+      if (title) title.textContent = '📊 Data';
+      if (subtitle) subtitle.textContent = 'Analyze your data';
       if (learnMore) learnMore.style.display = 'none';
     });
   </script>

--- a/shared/header.html
+++ b/shared/header.html
@@ -2,13 +2,13 @@
   <nav class="top-nav">
     <div class="nav-icon-links">
       <div class="icon-btn"><a href="index.html" aria-label="Tracker">📋</a></div>
-      <div class="icon-btn"><a href="ai.html" aria-label="AI Analyst">🤖</a></div>
+      <div class="icon-btn"><a href="ai.html" aria-label="Data">📊</a></div>
       <div class="icon-btn"><a href="profile.html" aria-label="Profile">👤</a></div>
     </div>
 
     <div class="nav-links">
       <a href="index.html">📋 Tracker</a>
-      <a href="ai.html">🤖 AI Analyst</a>
+      <a href="ai.html">📊 Data</a>
       <a href="profile.html">👤 Profile</a>
       <a href="settings.html">⚙️ Settings</a>
       <a href="admin.html">🛠️ Admin</a>


### PR DESCRIPTION
## Summary
- rename the AI analyst navigation icon and label to a data-themed entry
- retitle the AI page and update its subtitle copy to "Analyze your data"

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e19bafe5c08323a16fb437adc19caa