### PR TITLE
Add shared footer across pages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -12,6 +12,7 @@
     <h2 id="user-count-header">Total Users: 0</h2>
     <ul id="user-list"></ul>
   </div>
+  <div id="include-footer"></div>
   <script type="module" src="js/loadShared.js"></script>
   <script type="module" src="js/admin.js"></script>
 </body>

--- a/ai.html
+++ b/ai.html
@@ -75,6 +75,8 @@
     </div>
   </div>
 
+  <div id="include-footer"></div>
+
   <script type="module" src="js/loadShared.js"></script>
   <script type="module" src="js/ai.js"></script>
   <script type="module" src="js/auth.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -10,11 +10,119 @@ body {
   padding: 0;
   min-height: 100vh;
   background-color: #f1f5fb;
+  display: flex;
+  flex-direction: column;
 }
 
 .container {
   max-width: 1200px;
   margin: 0 auto;
+}
+
+body > .container {
+  flex: 1 0 auto;
+  width: 100%;
+}
+
+#include-footer,
+#include-modal {
+  flex-shrink: 0;
+}
+
+.app-footer {
+  background: linear-gradient(135deg, #2c3e50, #1f2a38);
+  color: #ecf0f1;
+  padding: 32px 16px;
+  box-shadow: 0 -6px 18px rgba(0, 0, 0, 0.08);
+}
+
+.footer-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  text-align: center;
+}
+
+.footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.footer-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 22px;
+}
+
+.footer-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.footer-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.footer-tagline {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(236, 240, 241, 0.82);
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px;
+  justify-content: center;
+}
+
+.footer-links a {
+  color: rgba(236, 240, 241, 0.82);
+  font-size: 14px;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover,
+.footer-links a:focus-visible {
+  color: #ffffff;
+  text-decoration: underline;
+}
+
+.footer-copy {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(236, 240, 241, 0.7);
+}
+
+@media (min-width: 768px) {
+  .footer-inner {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
+  }
+
+  .footer-brand {
+    justify-content: flex-start;
+  }
+
+  .footer-links {
+    justify-content: flex-end;
+  }
 }
 
   .header {

--- a/index.html
+++ b/index.html
@@ -122,6 +122,8 @@
 
   </div>
 
+  <div id="include-footer"></div>
+
   <!-- MODAL -->
   <div id="include-modal"></div>
 

--- a/js/loadShared.js
+++ b/js/loadShared.js
@@ -26,7 +26,8 @@ async function loadSharedComponents() {
     stats: 'shared/stats-bar.html',
     sort: 'shared/sort-controls.html',
     table: 'shared/table.html',
-    modal: 'shared/modal.html'
+    modal: 'shared/modal.html',
+    footer: 'shared/footer.html'
   };
 
   const loadPromises = Object.entries(includes).map(async ([key, path]) => {

--- a/login.html
+++ b/login.html
@@ -28,6 +28,8 @@
     </div>
   </div>
 
+  <div id="include-footer"></div>
+
   <!-- MODAL -->
   <div id="include-modal"></div>
   <script type="module" src="js/loadShared.js"></script>

--- a/profile.html
+++ b/profile.html
@@ -62,6 +62,8 @@
     <div id="include-table"></div>
   </div>
 
+  <div id="include-footer"></div>
+
   <!-- MODAL -->
   <div id="include-modal"></div>
 

--- a/register.html
+++ b/register.html
@@ -32,7 +32,9 @@
       <p class="auth-link">Already have an account? <a href="login.html">Log in</a></p>
     </div>
   </div>
-  
+
+  <div id="include-footer"></div>
+
   <!-- MODAL -->
   <div id="include-modal"></div>
   <script type="module" src="js/loadShared.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -26,7 +26,9 @@
           <button class="btn" id="logout-btn" style="display: none;">Log Out</button>
         </div>
       </div>
-    </div>
+  </div>
+
+  <div id="include-footer"></div>
 
     <script type="module" src="js/loadShared.js"></script>
     <script type="module" src="js/app.js"></script>

--- a/shared/footer.html
+++ b/shared/footer.html
@@ -1,0 +1,17 @@
+<footer class="app-footer" role="contentinfo">
+  <div class="footer-inner">
+    <div class="footer-brand">
+      <span class="footer-logo" aria-hidden="true">🎯</span>
+      <div class="footer-text">
+        <p class="footer-title">Betting Tracker</p>
+        <p class="footer-tagline">Track every wager. Improve every season.</p>
+      </div>
+    </div>
+    <nav class="footer-links" aria-label="Footer">
+      <a href="mailto:support@bettingtracker.app">Contact</a>
+      <a href="#">Privacy Policy</a>
+      <a href="#">Terms</a>
+    </nav>
+    <p class="footer-copy">© 2025 Betting Tracker. All rights reserved.</p>
+  </div>
+</footer>


### PR DESCRIPTION
## Summary
- add a shared footer partial and load it on every page for a consistent ending section
- adjust layout styles so the footer anchors to the bottom of the viewport while matching the app palette

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1d65b3ae8832394691375c78420e8