### PR TITLE
Remove CLV metric from profile stats bar

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -65,18 +65,6 @@ function calculateDemoStats() {
     .filter(b => b.outcome === 'Pending')
     .reduce((sum, b) => sum + (b.stake || 0), 0);
 
-  const clvEntries = bets
-    .map(b => {
-      const open = impliedProbFromOdds(b.odds);
-      const close = impliedProbFromOdds(b.closingOdds);
-      if (open === null || close === null) return null;
-      return (close - open) * 100;
-    })
-    .filter(value => value !== null);
-  const clv = clvEntries.length
-    ? clvEntries.reduce((sum, value) => sum + value, 0) / clvEntries.length
-    : null;
-
   return {
     totalBets: bets.length,
     winRate,
@@ -87,7 +75,6 @@ function calculateDemoStats() {
     mostProfitable,
     avgStake,
     winStreak,
-    clv,
     pendingExposure,
   };
 }
@@ -115,7 +102,6 @@ export async function updateStats() {
       mostProfitable,
       avgStake,
       winStreak,
-      clv,
     } = stats;
     if (el('totalBets')) el('totalBets').textContent = totalBets;
     if (el('winRate')) el('winRate').textContent = winRate.toFixed(1) + '%';
@@ -132,14 +118,5 @@ export async function updateStats() {
     if (el('bestSport')) el('bestSport').textContent = mostProfitable || '-';
     if (el('avgStake')) el('avgStake').textContent = '$' + avgStake.toFixed(2);
     if (el('winStreak')) el('winStreak').textContent = winStreak;
-    if (el('clv')) {
-      if (clv === null || Number.isNaN(clv)) {
-        el('clv').textContent = '—';
-        el('clv').className = 'stat-value';
-      } else {
-        el('clv').textContent = (clv >= 0 ? '+' : '') + clv.toFixed(1) + '%';
-        el('clv').className = 'stat-value ' + (clv >= 0 ? 'positive' : 'negative');
-      }
-    }
   }
 }

--- a/shared/stats-bar.html
+++ b/shared/stats-bar.html
@@ -5,7 +5,6 @@
   <div class="stat"><div class="stat-value" id="totalReturn">$0</div><div>Total Return</div></div>
   <div class="stat"><div class="stat-value" id="netProfit">$0</div><div>Net Profit/Loss</div></div>
   <div class="stat"><div class="stat-value" id="roi">0%</div><div>ROI</div></div>
-  <div class="stat"><div class="stat-value" id="clv">—</div><div>Avg CLV</div></div>
   <div class="stat"><div class="stat-value" id="bestSport">-</div><div>Most Profitable</div></div>
   <div class="stat"><div class="stat-value" id="avgStake">$0.00</div><div>Avg Stake</div></div>
   <div class="stat"><div class="stat-value" id="winStreak">0</div><div>Win Streak</div></div>


### PR DESCRIPTION
## Summary
- remove the Avg CLV tile from the shared stats bar used on the profile page
- stop computing and rendering CLV values in the stats updater

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1e41a5dd483239041339769e2b662