### PR TITLE
Allow 127.0.0.1:5501 origin for local login

### DIFF
--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -21,6 +21,7 @@ const exactOrigins = [
   process.env.FRONTEND_URL_ALT,   // e.g. https://your-custom-domain.com
   'http://localhost:3000',
   'http://localhost:5173',
+  'http://127.0.0.1:5501',
 ].filter(Boolean);
 
 // Allow preview URLs of the frontend project on Vercel


### PR DESCRIPTION
## Summary
- add 127.0.0.1:5501 to the list of allowed CORS origins so local logins from that port succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31e3e3920832399170c0f6769523f