### PR TITLE
Allow local development origins in CORS

### DIFF
--- a/betting-tracker-backend/server.js
+++ b/betting-tracker-backend/server.js
@@ -21,6 +21,7 @@ const exactOrigins = [
   process.env.FRONTEND_URL_ALT,   // e.g. https://your-custom-domain.com
   'http://localhost:3000',
   'http://localhost:5173',
+  'http://127.0.0.1:5501',
 ].filter(Boolean);
 
 // Allow preview URLs of the frontend project on Vercel
@@ -28,12 +29,20 @@ const previewRegexes = [
   /^https?:\/\/betting-tracker-nine(-[a-z0-9-]+)?\.vercel\.app$/i
 ];
 
+// Allow all localhost-style origins for local development, regardless of port
+const localDevRegexes = [
+  /^https?:\/\/localhost(?::\d+)?$/i,
+  /^https?:\/\/127\.0\.0\.1(?::\d+)?$/i,
+  /^https?:\/\/0\.0\.0\.0(?::\d+)?$/i,
+];
+
 const corsOptions = {
   origin(origin, callback) {
     if (!origin) return callback(null, true); // Same-origin or server-to-server
     const allowed =
       exactOrigins.includes(origin) ||
-      previewRegexes.some((re) => re.test(origin));
+      previewRegexes.some((re) => re.test(origin)) ||
+      localDevRegexes.some((re) => re.test(origin));
 
     if (allowed) return callback(null, true);
     return callback(new Error(`Not allowed by CORS: ${origin}`));


### PR DESCRIPTION
## Summary
- allow localhost-style origins with any port for CORS to support local development environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e31e3e3920832399170c0f6769523f