### PR TITLE
Align serverless user schema with backend stats

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -1,9 +1,25 @@
 import mongoose from 'mongoose';
 
+const StatsSchema = new mongoose.Schema(
+  {
+    totalBets: { type: Number, default: 0 },
+    winRate: { type: Number, default: 0 },
+    roi: { type: Number, default: 0 },
+    totalStaked: { type: Number, default: 0 },
+    totalReturn: { type: Number, default: 0 },
+    netProfit: { type: Number, default: 0 },
+    mostProfitable: { type: String, default: '-' },
+    avgStake: { type: Number, default: 0 },
+    winStreak: { type: Number, default: 0 }
+  },
+  { _id: false }
+);
+
 const UserSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   password: { type: String, required: true },
   role: { type: String, enum: ['user', 'admin'], default: 'user' },
+  stats: { type: StatsSchema, default: () => ({}) },
   openAiKey: { type: String, select: false, default: null },
   openAiKeySetAt: { type: Date, default: null }
 });


### PR DESCRIPTION
## Summary
- add a stats sub-schema to the serverless User model mirroring the full backend defaults
- embed the stats object in the User schema so both backends expose consistent fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3326e3de8832388312eb20738d7c6