### PR TITLE
Allow users to update their username from settings

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -225,6 +225,40 @@ body {
   min-width: 120px;
 }
 
+.inline-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: flex-end;
+}
+
+.inline-form label {
+  font-weight: 600;
+  font-size: 12px;
+  color: #2c3e50;
+}
+
+.inline-form input {
+  padding: 8px;
+  border: 1px solid #bdc3c7;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.form-feedback {
+  font-size: 13px;
+  margin-top: 6px;
+  color: #2c3e50;
+}
+
+.form-feedback.success {
+  color: #27ae60;
+}
+
+.form-feedback.error {
+  color: #e74c3c;
+}
+
 .form-group label {
   font-weight: bold;
   margin-bottom: 5px;

--- a/settings.html
+++ b/settings.html
@@ -21,6 +21,14 @@
         <div class="auth-controls">
           <h3>Account</h3>
           <p id="username-display" style="display: none;"></p>
+          <div id="username-section" style="display: none;">
+            <form id="username-form" class="inline-form">
+              <label for="username-input">Username</label>
+              <input type="text" id="username-input" name="username" minlength="3" maxlength="30" required />
+              <button class="btn" type="submit">Update Username</button>
+            </form>
+            <p id="username-message" class="form-feedback" aria-live="polite"></p>
+          </div>
           <a href="login.html" class="btn" id="login-btn">Log In</a>
           <a href="register.html" class="btn" id="signup-btn">Sign Up</a>
           <button class="btn" id="logout-btn" style="display: none;">Log Out</button>

--- a/src/utils/authTokens.js
+++ b/src/utils/authTokens.js
@@ -1,0 +1,22 @@
+import jwt from 'jsonwebtoken';
+
+export function buildAuthCookieOptions() {
+  const isProd = process.env.NODE_ENV === 'production';
+  const sameSite = isProd ? 'none' : 'lax';
+
+  return {
+    httpOnly: true,
+    secure: isProd,
+    sameSite,
+    path: '/',
+    maxAge: 7 * 24 * 60 * 60 * 1000,
+  };
+}
+
+export function signAuthToken(user) {
+  return jwt.sign(
+    { id: user._id, username: user.username, role: user.role },
+    process.env.JWT_SECRET,
+    { expiresIn: '7d' }
+  );
+}


### PR DESCRIPTION
## Summary
- extract shared helpers for issuing auth cookies and JWTs
- add a protected endpoint for updating the signed-in user's username and refreshing the session
- expose a username update form in Settings with client-side handling and feedback styles

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690673463c3883239a7559c30849d536